### PR TITLE
Parse uppercase headers in get_object and get_object_metadata

### DIFF
--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -276,7 +276,7 @@ put_bucket_policy(BucketName, Policy) ->
 -spec put_bucket_policy(string(), binary(), aws_config()) -> ok.
 put_bucket_policy(BucketName, Policy, Config)
   when is_list(BucketName), is_binary(Policy), is_record(Config, aws_config) ->
-    s3_simple_request(Config, put, BucketName, "/", "policy", [], Policy, []).
+    s3_simple_request(Config, put, BucketName, "/", "policy", [], Policy, [{"content-type", "application/json"}]).
 
 
 -spec list_objects(string()) -> proplist().


### PR DESCRIPTION
There is no reason to assume server to always return HTTP headers in lowercase, so we had better handle both.

Also I fixed `put_bucket_policy` to use correct content-type(json).