### PR TITLE
Use user's specified config rather than default_config

### DIFF
--- a/src/erlcloud_sqs.erl
+++ b/src/erlcloud_sqs.erl
@@ -149,7 +149,7 @@ get_queue_attributes(QueueName) ->
 -spec get_queue_attributes/2 :: (string(), all | [sqs_queue_attribute_name()] | aws_config()) -> proplist().
 get_queue_attributes(QueueName, Config)
   when is_record(Config, aws_config) ->
-    get_queue_attributes(QueueName, all, default_config());
+    get_queue_attributes(QueueName, all, Config);
 get_queue_attributes(QueueName, AttributeNames) ->
     get_queue_attributes(QueueName, AttributeNames, default_config()).
 


### PR DESCRIPTION
There's a small issue in the SQS code in which the default_config is being used rather than the one the user provided in the request. I believe that my edit reflects the original intention. 