### PR TITLE
Handling redrive policies in SQS 

### DIFF
--- a/src/erlcloud_sqs.erl
+++ b/src/erlcloud_sqs.erl
@@ -177,6 +177,7 @@ encode_attribute_name(created_timestamp) -> "CreatedTimestamp";
 encode_attribute_name(delay_seconds) -> "DelaySeconds";
 encode_attribute_name(receive_message_wait_time_seconds) -> "ReceiveMessageWaitTimeSeconds";
 encode_attribute_name(policy) -> "Policy";
+encode_attribute_name(redrive_policy) -> "RedrivePolicy";
 encode_attribute_name(all) -> "All".
 
 
@@ -191,7 +192,8 @@ decode_attribute_name("LastModifiedTimestamp") -> last_modified_timestamp;
 decode_attribute_name("CreatedTimestamp") -> created_timestamp;
 decode_attribute_name("DelaySeconds") -> delay_seconds;
 decode_attribute_name("ReceiveMessageWaitTimeSeconds") -> receive_message_wait_time_seconds;
-decode_attribute_name("Policy") -> policy.
+decode_attribute_name("Policy") -> policy;
+decode_attribute_name("RedrivePolicy") -> redrive_policy.
 
 -spec list_queues/0 :: () -> [string()].
 list_queues() ->

--- a/src/erlcloud_sqs.erl
+++ b/src/erlcloud_sqs.erl
@@ -161,9 +161,8 @@ get_queue_attributes(QueueName, AttributeNames, Config)
     Doc = sqs_xml_request(Config, QueueName, "GetQueueAttributes",
                           erlcloud_aws:param_list([encode_attribute_name(N) || N <- AttributeNames], "AttributeName")),
     Attrs = decode_attributes(xmerl_xpath:string("GetQueueAttributesResult/Attribute", Doc)),
-    [{decode_attribute_name(Name),
-      case Name of "Policy" -> Value; "QueueArn" -> Value; _ -> list_to_integer(Value) end} ||
-        {Name, Value} <- Attrs].
+    [{decode_attribute_name(Name), decode_attribute_value(Name, Value)} || {Name, Value} <- Attrs].
+
 
 encode_attribute_name(message_retention_period) -> "MessageRetentionPeriod";
 encode_attribute_name(queue_arn) -> "QueueArn";
@@ -194,6 +193,13 @@ decode_attribute_name("DelaySeconds") -> delay_seconds;
 decode_attribute_name("ReceiveMessageWaitTimeSeconds") -> receive_message_wait_time_seconds;
 decode_attribute_name("Policy") -> policy;
 decode_attribute_name("RedrivePolicy") -> redrive_policy.
+
+
+decode_attribute_value("Policy", Value) -> Value;
+decode_attribute_value("QueueArn", Value) -> Value;
+decode_attribute_value("RedrivePolicy", Value) -> Value;
+decode_attribute_value(_, Value) -> list_to_integer(Value).
+
 
 -spec list_queues/0 :: () -> [string()].
 list_queues() ->


### PR DESCRIPTION
SQS queues have an optional "redrive policy" that sends messages to a specified dead letter queue after a certain number of failed delivery attempts. When retrieving the attributes of a queue with such a policy, the attribute name ("RedrivePolicy") was not recognized. I added attribute encoder and decoder clauses, choosing not to further decode the JSON attribute value, in keeping with the way the "Policy" attribute is handled.