### PR TITLE
Fix response header used to obtain version_id

### DIFF
--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -568,7 +568,7 @@ get_object_torrent(BucketName, Key) ->
 get_object_torrent(BucketName, Key, Config) ->
     {Headers, Body} = s3_request(Config, get, BucketName, [$/|Key], "torrent", [], <<>>, []),
     [{delete_marker, list_to_existing_atom(proplists:get_value("x-amz-delete-marker", Headers, "false"))},
-     {version_id, proplists:get_value("x-amz-delete-marker", Headers, "false")},
+     {version_id, proplists:get_value("x-amz-version-id", Headers, "null")},
      {torrent, Body}].
 
 -spec list_object_versions(string()) -> proplist().


### PR DESCRIPTION
erlcloud_s3:get_object_torrent/3 used x-amz-delete-marker to obtain the
version_id from repsonse headers. Changed to x-amz-version-id (and
default to "null) as done in other functions such as put_object/6 and
copy_object/6.

This was mentioned in issue https://github.com/gleber/erlcloud/issues/138