### PR TITLE
Change default value for version_id to "null"

### DIFF
--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -553,7 +553,7 @@ get_object_metadata(BucketName, Key, Options, Config) ->
      {content_type, proplists:get_value("content-type", Headers)},
      {content_encoding, proplists:get_value("content-encoding", Headers)},
      {delete_marker, list_to_existing_atom(proplists:get_value("x-amz-delete-marker", Headers, "false"))},
-     {version_id, proplists:get_value("x-amz-version-id", Headers, "false")}|extract_metadata(Headers)].
+     {version_id, proplists:get_value("x-amz-version-id", Headers, "null")}|extract_metadata(Headers)].
 
 extract_metadata(Headers) ->
     [{Key, Value} || {Key = "x-amz-meta-" ++ _, Value} <- Headers].


### PR DESCRIPTION
erlcloud_s3:get_object_metadata/4 used a default value of "false" in its
proplists:get_value() call. Elsewhere, "null" is used as default for
version_id (e.g., get_object/4). That matches the docs at
http://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonResponseHeaders.html

Related to issue https://github.com/gleber/erlcloud/issues/138