### PR TITLE
Update elb API date version to 2012-06-01

### DIFF
--- a/src/erlcloud_elb.erl
+++ b/src/erlcloud_elb.erl
@@ -18,7 +18,7 @@
 -include_lib("erlcloud/include/erlcloud.hrl").
 -include_lib("erlcloud/include/erlcloud_aws.hrl").
 
--define(API_VERSION, "2009-05-15").
+-define(API_VERSION, "2012-06-01").
 
 -import(erlcloud_xml, [get_text/2]).
 


### PR DESCRIPTION
The updated 2012 API works with Amazon's VPC; 2009 API does not.  Tested register_instance.