### PR TITLE
Support for lhttpc options

### DIFF
--- a/include/erlcloud_aws.hrl
+++ b/include/erlcloud_aws.hrl
@@ -35,6 +35,7 @@
           timeout=10000::timeout(),
           cloudtrail_raw_result=false::boolean(),
           http_client=lhttpc::erlcloud_httpc:request_fun(),
+          lhttpc_options=[]::proplists:proplist(),
 
           %% Default to not retry failures (for backwards compatability).
           %% Recommended to be set to default_retry to provide recommended retry behavior.

--- a/src/erlcloud_httpc.erl
+++ b/src/erlcloud_httpc.erl
@@ -40,8 +40,9 @@ request(URL, Method, Hdrs, Body, Timeout,
     when is_function(F, 6) ->
     F(URL, Method, Hdrs, Body, Timeout, Config).
 
-request_lhttpc(URL, Method, Hdrs, Body, Timeout, _Config) ->
-    lhttpc:request(URL, Method, Hdrs, Body, Timeout, []).
+request_lhttpc(URL, Method, Hdrs, Body, Timeout, 
+	       #aws_config{lhttpc_options = Options }) ->
+    lhttpc:request(URL, Method, Hdrs, Body, Timeout, Options).
 
 request_httpc(URL, Method, Hdrs, <<>>, Timeout, _Config) ->
     HdrsStr = [{to_list_string(K), to_list_string(V)} || {K, V} <- Hdrs],

--- a/test/erlcloud_aws_tests.erl
+++ b/test/erlcloud_aws_tests.erl
@@ -1,5 +1,6 @@
 -module(erlcloud_aws_tests).
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("erlcloud_aws.hrl").
 
 request_test_() ->
     {foreach,
@@ -7,7 +8,16 @@ request_test_() ->
      fun stop/1,
      [fun request_default_test/1,
       fun request_prot_host_port_str_test/1,
-      fun request_prot_host_port_int_test/1]}.
+      fun request_prot_host_port_int_test/1
+     ]}.
+
+lhttpc_options_test_() ->
+    {foreach,
+     fun start_lhttpc/0,
+     fun stop_lhttpc/1,
+     [fun lhttpc_options_are_empty_list_by_default/1,
+      fun lhttpc_options_get_passed_down/1 
+     ]}.
 
 start() ->
     meck:new(erlcloud_httpc),
@@ -16,6 +26,15 @@ start() ->
 
 stop(_) ->
     meck:unload(erlcloud_httpc).
+
+
+start_lhttpc() ->
+    meck:new(lhttpc),
+    meck:expect(lhttpc, request, fun(_,_,_,_,_,_) -> {ok, {{200, "OK"}, [], ok}} end),
+    ok.
+
+stop_lhttpc(_) ->
+    meck:unload(lhttpc).
 
 request_default_test(_) ->
     ok = erlcloud_aws:aws_request(get, "host", "/", [], "id", "key"),
@@ -32,12 +51,28 @@ request_prot_host_port_int_test(_) ->
     Url = get_url_from_history(meck:history(erlcloud_httpc)),
     test_url(http, "host1", 9999, "/path1", Url).
 
+
+lhttpc_options_are_empty_list_by_default(_) ->
+    ok = erlcloud_aws:aws_request(get, "http", "host1", 9999, "/path1", [], "id", "key"),
+    LHTTPCOptions = get_config_from_history(meck:history(lhttpc)),
+    ?_assertEqual([], LHTTPCOptions).
+
+lhttpc_options_get_passed_down(_) ->
+    Config = #aws_config{lhttpc_options = [{foo, bar}], 
+			 access_key_id="id",
+			 secret_access_key="key"},
+    ok = erlcloud_aws:aws_request(get, "http", "example.com", 8008, "/", [], Config),
+    LHTTPCOptions = get_config_from_history(meck:history(lhttpc)),
+    ?_assertEqual([{foo, bar}], LHTTPCOptions).
+
 % ==================
 % Internal functions
 % ==================
 
 get_url_from_history([{_, {erlcloud_httpc, request, [Url, _, _, _, _, _]}, _}]) ->
     Url.
+get_config_from_history([{_, {lhttpc, request, [_, _, _, _, _, Config]}, _}]) ->
+    Config.
 
 test_url(ExpScheme, ExpHost, ExpPort, ExpPath, Url) ->
     {ok, {Scheme, _UserInfo, Host, Port, Path, _Query}} = http_uri:parse(Url),


### PR DESCRIPTION
`erlcloud_httpc` makes it possible to change underlying http clients,
however it doesn't allow to pass options to them.
This PR adds possibility to pass options to `lhttpc`
by adding `lhttpc_options` in `erlcloud_aws` record.
This comes in handy when you want to add a pool of workers to http client.