### PR TITLE
Update erlcloud to use AWS v4 signature and use for AS and EC2

### DIFF
--- a/src/erlcloud_as.erl
+++ b/src/erlcloud_as.erl
@@ -333,5 +333,5 @@ get_text(Label, Doc) ->
 -spec as_query(aws_config(), string(), list({string(), string()}), string()) -> {ok, term()} | {error, term}.
 as_query(Config, Action, Params, ApiVersion) ->
     QParams = [{"Action", Action}, {"Version", ApiVersion}|Params],
-    erlcloud_aws:aws_request_xml2(post, Config#aws_config.as_host, 
-                                  "/", QParams, Config).
+    erlcloud_aws:aws_request_xml4(post, Config#aws_config.as_host, 
+                                  "/", QParams, "autoscaling", Config).

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -4,6 +4,7 @@
          aws_request_xml/5, aws_request_xml/6, aws_request_xml/7, aws_request_xml/8,
          aws_request2/7,
          aws_request_xml2/5, aws_request_xml2/7,
+         aws_request_xml4/6,aws_request_xml4/8,
          aws_request_form/8,
          param_list/2, default_config/0, update_config/1, format_timestamp/1,
          http_headers_body/1,
@@ -37,6 +38,16 @@ aws_request_xml2(Method, Host, Path, Params, #aws_config{} = Config) ->
     aws_request_xml2(Method, undefined, Host, undefined, Path, Params, Config).
 aws_request_xml2(Method, Protocol, Host, Port, Path, Params, #aws_config{} = Config) ->
     case aws_request2(Method, Protocol, Host, Port, Path, Params, Config) of
+        {ok, Body} ->
+            {ok, element(1, xmerl_scan:string(binary_to_list(Body)))};
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+aws_request_xml4(Method, Host, Path, Params, Service, #aws_config{} = Config) ->
+    aws_request_xml4(Method, undefined, Host, undefined, Path, Params, Service, Config).
+aws_request_xml4(Method, Protocol, Host, Port, Path, Params, Service, #aws_config{} = Config) ->
+    case aws_request4(Method, Protocol, Host, Port, Path, Params, Service, Config) of
         {ok, Body} ->
             {ok, element(1, xmerl_scan:string(binary_to_list(Body)))};
         {error, Reason} ->
@@ -89,6 +100,38 @@ aws_request2_no_update(Method, Protocol, Host, Port, Path, Params, #aws_config{}
     
     aws_request_form(Method, Protocol, Host, Port, Path, Query, [], Config).
 
+aws_request4(Method, Protocol, Host, Port, Path, Params, Service, Config) ->
+    case update_config(Config) of
+        {ok, Config1} ->
+            aws_request4_no_update(Method, Protocol, Host, Port, Path, Params, Service, Config1);
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+aws_request4_no_update(Method, Protocol, Host, Port, Path, Params, Service, #aws_config{} = Config) ->
+    QueryToSign = erlcloud_http:make_query_string(Params),
+    
+    Headers = [{"host", Host}],
+
+    Region =
+        case string:tokens(Host, ".") of
+            [_, Value, _, _] ->
+                Value;
+            _ ->
+                "us-east-1"
+        end,
+
+    SignedHeaders = case Method of
+        get -> sign_v4(Method, Config, Headers, Params, "", Region, Service);
+        post -> sign_v4(Method, Config, Headers, "", QueryToSign, Region, Service)
+    end,
+
+    aws_request_form(Method, Protocol, Host, Port, Path, QueryToSign, SignedHeaders, Config).
+
+
+-spec aws_request_form(Method :: atom(), Protocol :: undefined | string(), Host :: string(),
+                        Port :: undefined | integer() | string(), Path :: string(), Form :: string(),
+                        Headers :: list(), Config :: aws_config()) -> {ok, binary()} | {error, tuple()}.
 aws_request_form(Method, Protocol, Host, Port, Path, Form, Headers, Config) ->
     UProtocol = case Protocol of
         undefined -> "https://";
@@ -276,13 +319,19 @@ request_to_return(#aws_request{response_type = error,
 %% TODO additional parameters - currently only supports what is needed for DynamoDB
 -spec sign_v4(aws_config(), headers(), binary(), string(), string()) -> headers().
 sign_v4(Config, Headers, Payload, Region, Service) ->
+    sign_v4(post, Config, Headers, [], Payload, Region, Service).
+
+-spec sign_v4(atom(), aws_config(), headers(), binary(), binary(), string(), string()) -> headers().
+sign_v4(Method, Config, Headers, QueryParams, Payload, Region, Service) ->
     Date = iso_8601_basic_time(),
     Headers1 = [{"x-amz-date", Date} | Headers],
     Headers2 = case Config#aws_config.security_token of
                    undefined -> Headers1;
                    Token -> [{"x-amz-security-token", Token} | Headers1]
                end,
-    {Request, SignedHeaders} = canonical_request("POST", "/", "", Headers2, Payload),
+    CanonicalQueryString = canonical_query_string(QueryParams),
+    MethodString = string:to_upper(atom_to_list(Method)),
+    {Request, SignedHeaders} = canonical_request(MethodString, "/", CanonicalQueryString, Headers2, Payload),
     CredentialScope = credential_scope(Date, Region, Service),
     ToSign = to_sign(Date, CredentialScope, Request),
     SigningKey = signing_key(Config, Date, Region, Service),
@@ -312,6 +361,18 @@ canonical_headers(Headers) ->
     Canonical = [[Name, $:, Value, $\n] || {Name, Value} <- Sorted],
     Signed = string:join([Name || {Name, _} <- Sorted], ";"),
     {Canonical, Signed}.
+
+%% @doc calculate canonical query string out of query params and according to v4 documentation
+canonical_query_string([]) ->
+    "";
+canonical_query_string(Params) ->
+    Normalized = [{erlcloud_http:url_encode(Name), erlcloud_http:url_encode(erlcloud_http:value_to_string(Value))} || {Name, Value} <- Params],
+    Sorted = lists:keysort(1, Normalized),
+    string:join([case Value of
+                     [] -> [Key, "="];
+                     _ -> [Key, "=", Value]
+                 end
+                 || {Key, Value} <- Sorted, Value =/= none, Value =/= undefined], "&").
 
 trimall(Value) ->
     %% TODO - remove excess internal whitespace in header values

--- a/src/erlcloud_ec2.erl
+++ b/src/erlcloud_ec2.erl
@@ -2765,8 +2765,8 @@ ec2_query2(Config, Action, Params) ->
 
 ec2_query2(Config, Action, Params, ApiVersion) ->
     QParams = [{"Action", Action}, {"Version", ApiVersion}|Params],
-    erlcloud_aws:aws_request_xml2(post, Config#aws_config.ec2_host,
-                                  "/", QParams, Config).
+    erlcloud_aws:aws_request_xml4(post, Config#aws_config.ec2_host,
+                                  "/", QParams, "ec2", Config).
 
 default_config() -> erlcloud_aws:default_config().
 

--- a/src/erlcloud_http.erl
+++ b/src/erlcloud_http.erl
@@ -1,5 +1,5 @@
 -module(erlcloud_http).
--export([make_query_string/1, make_query_string/2, url_encode/1, url_encode_loose/1]).
+-export([make_query_string/1, make_query_string/2, value_to_string/1, url_encode/1, url_encode_loose/1]).
 
 encode_query_term(Key, [], no_assignment) ->
   [Key];


### PR DESCRIPTION
Finally got around to fixing that v4 signature. I followed the initial idea of @ransomr and extended it to allow GETs as well (using canonical query string, cf. http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html).

I used it for EC2 and AS on eu-central-1 (which only allows v4) and as far as I can tell that works with both GET and POST.