### PR TITLE
add .rebar and erl_crash.dump to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,12 @@ _build
 ebin/*.beam
 ebin/*.app
 .eunit/
+.rebar/
 rebar
 *.sublime-*
 deps/
 doc/
+erl_crash.dump
 .edts
 *[#]*[#]
 *[#]*


### PR DESCRIPTION
As part of #178, I got these files in my local directory. I thought they should be added to the .gitignore file.

* the .rebar directory is generated when I use rebar on OS X.
* erl_crash.dump is generated when the Erlang VM crashes.