### PR TITLE
Add legacy Exists and Value parameters to Expected

### DIFF
--- a/src/erlcloud_ddb2.erl
+++ b/src/erlcloud_ddb2.erl
@@ -27,7 +27,7 @@
 %% `42'. To specify the AWS binary or set types an explicit `Type'
 %% must be provided. For example: `{b, <<1,2,3>>}' or `{ns,
 %% [4,5,6]}'. Note that binary values will be base64 encoded and
-%% decoded automatically. Since some atoms (such as `false', `not_null',
+%% decoded automatically. Since some atoms (such as `true', `false', `not_null',
 %% `null', `undefined', `delete', etc) have special meanings in some cases,
 %% use them carefully.
 %%
@@ -245,7 +245,9 @@ default_config() -> erlcloud_aws:default_config().
                          {l, [in_attr_value()]} |
                          {m, [in_attr()]}.
 -type in_attr() :: {attr_name(), in_attr_value()}.
--type in_expected_item() :: {attr_name(), false} | condition().
+-type in_expected_item() :: {attr_name(), false} |
+                            {attr_name(), true, in_attr_value()} |
+                            condition().
 -type in_expected() :: maybe_list(in_expected_item()).
 -type in_item() :: [in_attr()].
 
@@ -426,6 +428,9 @@ dynamize_conditional_op('or') ->
 -spec dynamize_expected_item(in_expected_item()) -> json_pair().
 dynamize_expected_item({Name, false}) ->
     {Name, [{<<"Exists">>, false}]};
+dynamize_expected_item({Name, true, Value}) ->
+    {Name, [{<<"Exists">>, true},
+            {<<"Value">>, [dynamize_value(Value)]}]};
 dynamize_expected_item(Condition) ->
     dynamize_condition(Condition).
 


### PR DESCRIPTION
Just in case someone might need that.

Assuming there's an existing expected condition which is _`{Name, Value, Op}`_, of which

  * _`Value`_ is atom `true`, which assumed to be inferred as `{"S": "true"`}; and
  * _`Op`_ is one of `eq`, `ne`, `le`, `lt`, `ge`, `gt`, `contains`, `not_contains`, `begins_with`.

Iff in this case, it becomes _equals to atom string `Op`_ (eg. `{"S": "lt"}`), which used to be _comparing with `{"S": "true"}`_

Actually, seldom people would have used atoms as string values. I believe no one would come into this circumstance incidentally.