### PR TITLE
Return status and do not raise errors in sns:publish/5 & derivatives

### DIFF
--- a/src/erlcloud_sns.erl
+++ b/src/erlcloud_sns.erl
@@ -89,6 +89,8 @@
 
 -type(sns_subscribe_protocol_type () :: http | https | email | 'email-json' | sms | sqs | application).
 
+-type(sns_response() :: {ok, string()} | {error, any()}).
+
 -export_type([sns_acl/0, sns_endpoint_attribute/0,
               sns_message/0, sns_application/0, sns_endpoint/0]).
 
@@ -303,15 +305,15 @@ list_platform_applications(NextToken, AccessKeyID, SecretAccessKey) ->
 
 
 
--spec publish_to_topic/2 :: (string(), sns_message()) -> string().
--spec publish_to_topic/3 :: (string(), sns_message(), undefined|string()) -> string().
--spec publish_to_topic/4 :: (string(), sns_message(), undefined|string(), aws_config()) -> string().
--spec publish_to_topic/5 :: (string(), sns_message(), undefined|string(), string(), string()) -> string().
--spec publish_to_target/2 :: (string(), sns_message()) -> string().
--spec publish_to_target/3 :: (string(), sns_message(), undefined|string()) -> string().
--spec publish_to_target/4 :: (string(), sns_message(), undefined|string(), aws_config()) -> string().
--spec publish_to_target/5 :: (string(), sns_message(), undefined|string(), string(), string()) -> string().
--spec publish/5 :: (topic|target, string(), sns_message(), undefined|string(), aws_config()) -> string().
+-spec publish_to_topic/2 :: (string(), sns_message()) -> sns_response().
+-spec publish_to_topic/3 :: (string(), sns_message(), undefined|string()) -> sns_response().
+-spec publish_to_topic/4 :: (string(), sns_message(), undefined|string(), aws_config()) -> sns_response().
+-spec publish_to_topic/5 :: (string(), sns_message(), undefined|string(), string(), string()) -> sns_response().
+-spec publish_to_target/2 :: (string(), sns_message()) -> sns_response().
+-spec publish_to_target/3 :: (string(), sns_message(), undefined|string()) -> sns_response().
+-spec publish_to_target/4 :: (string(), sns_message(), undefined|string(),aws_config()) -> sns_response().
+-spec publish_to_target/5 :: (string(), sns_message(), undefined|string(), string(), string()) -> sns_response().
+-spec publish/5 :: (topic|target, string(), sns_message(), undefined|string(), aws_config()) -> sns_response().
 
 publish_to_topic(TopicArn, Message) ->
     publish_to_topic(TopicArn, Message, undefined).
@@ -349,12 +351,12 @@ publish(Type, RecipientArn, Message, Subject, Config) ->
             undefined -> [];
             Subject -> [{"Subject", Subject}]
         end,
-    Doc =
-        sns_xml_request(
-            Config, "Publish",
-            RecipientParam ++ MessageParams ++ SubjectParam),
-    erlcloud_xml:get_text(
-        "PublishResult/MessageId", Doc).
+    case sns_xml_request2(
+           Config, "Publish",
+           RecipientParam ++ MessageParams ++ SubjectParam) of
+      {ok, Doc} -> {ok, erlcloud_xml:get_text("PublishResult/MessageId", Doc)};
+      Error -> Error
+    end.
 
 
 


### PR DESCRIPTION
This begins the process to starting to align the sns module with many of the others in the app.

I'm not sure what the policy is on this project for introducing backwards incompatible API changes, but this does change the return spec of publish/5, publish_to_topic/* and publish_to_target/*.