### PR TITLE
Add consistent_read opt to scan

### DIFF
--- a/src/erlcloud_ddb2.erl
+++ b/src/erlcloud_ddb2.erl
@@ -1838,6 +1838,7 @@ q(Table, KeyConditionsOrExpression, Opts, Config) ->
                     expression_attribute_values_opt() |
                     projection_expression_opt() |
                     attributes_to_get_opt() |
+                    consistent_read_opt() |
                     {filter_expression, expression()} |
                     conditional_op_opt() |
                     {scan_filter, conditions()} |
@@ -1857,6 +1858,7 @@ scan_opts() ->
      expression_attribute_values_opt(),
      projection_expression_opt(),
      attributes_to_get_opt(),
+     consistent_read_opt(),
      {filter_expression, <<"FilterExpression">>, fun dynamize_expression/1},
      conditional_op_opt(),
      {scan_filter, <<"ScanFilter">>, fun dynamize_conditions/1},

--- a/test/erlcloud_ddb2_tests.erl
+++ b/test/erlcloud_ddb2_tests.erl
@@ -2600,6 +2600,15 @@ scan_input_tests(_) ->
 }"
             }),
          ?_ddb_test(
+            {"Scan consistent read",
+             ?_f(erlcloud_ddb2:scan(<<"Reply">>,
+                                   [{consistent_read, true}])), "
+{
+    \"TableName\": \"Reply\",
+    \"ConsistentRead\": true
+}"
+            }),
+         ?_ddb_test(
             {"Scan exclusive start key",
              ?_f(erlcloud_ddb2:scan(<<"Reply">>, 
                                    [{exclusive_start_key, [{<<"ForumName">>, {s, <<"Amazon DynamoDB">>}},


### PR DESCRIPTION
DynamoDB added  Read Consistency support for Scan, see [document history](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DocumentHistory.html) for more detail.