### PR TITLE
erlcloud_sns_tests: call configure during test setup

### DIFF
--- a/test/erlcloud_sns_tests.erl
+++ b/test/erlcloud_sns_tests.erl
@@ -17,7 +17,8 @@ sns_publish_test_() ->
 start() ->
     meck:new(erlcloud_httpc),
     meck:expect(erlcloud_httpc, request,
-                 fun(_,_,_,_,_,_) -> mock_httpc_response() end).
+                 fun(_,_,_,_,_,_) -> mock_httpc_response() end),
+    erlcloud_sns:configure(string:copies("A", 20), string:copies("a", 40)).
 
 stop(_) ->
     meck:unload(erlcloud_httpc).


### PR DESCRIPTION
* fixes an issue where an AWS metadata lookup is triggered and the mecked XML is returned to a lookup that expects JSON, making the unit tests fail.

@ransomr I don't know how this was working for you before, but I got failures in both Erlang R16B03-1 and 17.4. This seems to resolve it entirely (and is used in most other test suites from what I see).

Snippet of the error I get:
```sh
$ make eunit
```
```sh
# ...
undefined
*** instantiation of subtests failed ***
**in function jsx_decoder:value/4 (src/jsx_decoder.erl, line 234)
in call from erlcloud_aws:get_credentials_from_metadata/1 (src/erlcloud_aws.erl, line 262)
in call from erlcloud_aws:update_config/1 (src/erlcloud_aws.erl, line 211)
in call from erlcloud_aws:aws_request2/7 (src/erlcloud_aws.erl, line 75)
in call from erlcloud_aws:aws_request_xml2/7 (src/erlcloud_aws.erl, line 40)
in call from erlcloud_sns:sns_xml_request/3 (src/erlcloud_sns.erl, line 515)
in call from erlcloud_sns:publish/5 (src/erlcloud_sns.erl, line 353)
in call from erlcloud_sns_tests:defaults_to_http/1 (test/erlcloud_sns_tests.erl, line 27)
**error:badarg


undefined
*** context setup failed ***
**in function meck_proc:start/2 (src/meck_proc.erl, line 94)
  called as start(erlcloud_httpc,[])
in call from erlcloud_sns_tests:start/0 (test/erlcloud_sns_tests.erl, line 18)
# ...
```