### PR TITLE
erlcloud_ddb2: support ConsistentRead option in scan

### DIFF
--- a/src/erlcloud_ddb2.erl
+++ b/src/erlcloud_ddb2.erl
@@ -1840,6 +1840,7 @@ q(Table, KeyConditionsOrExpression, Opts, Config) ->
                     attributes_to_get_opt() |
                     {filter_expression, expression()} |
                     conditional_op_opt() |
+                    consistent_read_opt() |
                     {scan_filter, conditions()} |
                     {limit, pos_integer()} |
                     {exclusive_start_key, key() | undefined} |
@@ -1859,6 +1860,7 @@ scan_opts() ->
      attributes_to_get_opt(),
      {filter_expression, <<"FilterExpression">>, fun dynamize_expression/1},
      conditional_op_opt(),
+     consistent_read_opt(),
      {scan_filter, <<"ScanFilter">>, fun dynamize_conditions/1},
      {limit, <<"Limit">>, fun id/1},
      {exclusive_start_key, <<"ExclusiveStartKey">>, fun dynamize_key/1},

--- a/test/erlcloud_ddb2_tests.erl
+++ b/test/erlcloud_ddb2_tests.erl
@@ -2640,6 +2640,14 @@ scan_input_tests(_) ->
     \"ExpressionAttributeValues\": {\":val\": {\"S\": \"joe@example.com\"}},
     \"ReturnConsumedCapacity\": \"TOTAL\"
 }"
+            }),
+         ?_ddb_test(
+            {"Scan with consistent read option",
+             ?_f(erlcloud_ddb2:scan(<<"Reply">>, [{consistent_read, true}])), "
+{
+    \"TableName\": \"Reply\",
+    \"ConsistentRead\": true
+}"
             })
         ],
 


### PR DESCRIPTION
* added by Amazon per the [API Documentation](http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Scan.html#DDB-Scan-request-ConsistentRead)

I got an email about this from Amazon this morning. Seemed worth adding.