### PR TITLE
erlcloud_http_tests: set encoding to utf-8 explicitly

### DIFF
--- a/test/erlcloud_http_tests.erl
+++ b/test/erlcloud_http_tests.erl
@@ -1,3 +1,4 @@
+%% -*- coding: utf-8 -*-
 -module(erlcloud_http_tests).
 -include_lib("eunit/include/eunit.hrl").
 


### PR DESCRIPTION
Resolves #185.