### PR TITLE
Configurable erlcloud_s3:delete_objects_batch

### DIFF
--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -12,7 +12,8 @@
          list_objects/1, list_objects/2, list_objects/3,
          list_object_versions/1, list_object_versions/2, list_object_versions/3,
          copy_object/4, copy_object/5, copy_object/6,
-         delete_objects_batch/2, explore_dirstructure/3,
+         delete_objects_batch/2, delete_objects_batch/3,
+         explore_dirstructure/3,
          delete_object/2, delete_object/3,
          delete_object_version/3, delete_object_version/4,
          get_object/2, get_object/3, get_object/4,
@@ -198,10 +199,13 @@ delete_bucket(BucketName, Config)
   when is_list(BucketName) ->
     s3_simple_request(Config, delete, BucketName, "/", "", [], <<>>, []).
 
--spec delete_objects_batch(string(), list()) -> no_return().
 
+-spec delete_objects_batch(string(), list()) -> no_return().
 delete_objects_batch(Bucket, KeyList) ->
-    Config = default_config(),
+    delete_objects_batch(Bucket, KeyList, default_config()).
+
+-spec delete_objects_batch(string(), list(), aws_config()) -> no_return().
+delete_objects_batch(Bucket, KeyList, Config) ->
     Data = lists:map(fun(Item) ->
             lists:concat(["<Object><Key>", Item, "</Key></Object>"]) end, 
                 KeyList),
@@ -209,9 +213,6 @@ delete_objects_batch(Bucket, KeyList) ->
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?><Delete>" ++ Data ++ "</Delete>", 
                 utf8),
 
-    
-    
-    
     Len = integer_to_list(string:len(Payload)),
     Url = lists:flatten([Config#aws_config.s3_scheme, 
                 Bucket, ".", Config#aws_config.s3_host, port_spec(Config), "/?delete"]),


### PR DESCRIPTION
Add erlcloud_s3:delete_objects_batch/3 (with custom aws config). It's may be more useful than just working with a default aws config.