### PR TITLE
Added a little flexibility to S3 to make this library easier to use with things like CEPH.

### DIFF
--- a/include/erlcloud_aws.hrl
+++ b/include/erlcloud_aws.hrl
@@ -6,6 +6,7 @@
           s3_scheme="https://"::string(),
           s3_host="s3.amazonaws.com"::string(),
           s3_port=80::non_neg_integer(),
+          s3_bucket_after_host=false::boolean(),
           sdb_host="sdb.amazonaws.com"::string(),
           elb_host="elasticloadbalancing.amazonaws.com"::string(),
           ses_host="email.us-east-1.amazonaws.com"::string(),

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -7,7 +7,7 @@
          aws_request_xml4/6,aws_request_xml4/8,
          aws_request_form/8,
          param_list/2, default_config/0, update_config/1,
-         change_config/1, format_timestamp/1,
+         configure/1, format_timestamp/1,
          http_headers_body/1,
          request_to_return/1,
          sign_v4/5]).
@@ -219,11 +219,11 @@ update_config(#aws_config{} = Config) ->
                    security_token = Credentials#metadata_credentials.security_token}}
     end.
 
--spec change_config(aws_config()) -> {ok, aws_config()} | {error, term()}.
+-spec configure(aws_config()) -> {ok, aws_config()}.
 
-change_config(Config) ->
+configure(#aws_config{} = Config) ->
     put(aws_config, Config),
-    ok.
+    {ok, default_config()}.
 
 -spec get_metadata_credentials(aws_config()) -> {ok, #metadata_credentials{}} | {error, term()}.
 get_metadata_credentials(Config) ->

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -6,7 +6,8 @@
          aws_request_xml2/5, aws_request_xml2/7,
          aws_request_xml4/6,aws_request_xml4/8,
          aws_request_form/8,
-         param_list/2, default_config/0, update_config/1, format_timestamp/1,
+         param_list/2, default_config/0, update_config/1,
+         change_config/1, format_timestamp/1,
          http_headers_body/1,
          request_to_return/1,
          sign_v4/5]).
@@ -217,6 +218,12 @@ update_config(#aws_config{} = Config) ->
                    secret_access_key = Credentials#metadata_credentials.secret_access_key,
                    security_token = Credentials#metadata_credentials.security_token}}
     end.
+
+-spec change_config(aws_config()) -> {ok, aws_config()} | {error, term()}.
+
+change_config(Config) ->
+    put(aws_config, Config),
+    ok.
 
 -spec get_metadata_credentials(aws_config()) -> {ok, #metadata_credentials{}} | {error, term()}.
 get_metadata_credentials(Config) ->

--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -1019,7 +1019,11 @@ s3_request(Config, Method, Host, Path, Subreasource, Params, POSTData, Headers) 
 s3_request2(Config, Method, Host, Path, Subresource, Params, POSTData, Headers) ->
     case erlcloud_aws:update_config(Config) of
         {ok, Config1} ->
-            s3_request2_no_update(Config1, Method, Host, Path, Subresource, Params, POSTData, Headers);
+            %% The name of a bucket is originally passed as Host parameter, but our host doesn't change.
+            %% So instead I've modified this line so the name of a bucket is passed between the host adress and the object key (Path parameter).
+            %% Original line:
+            %% s3_request2_no_update(Config1, Method, Host, Path, Subresource, Params, POSTData, Headers);
+            s3_request2_no_update(Config1, Method, "", [$/|Host] ++ Path, Subresource, Params, POSTData, Headers);
         {error, Reason} ->
             {error, Reason}
     end.


### PR DESCRIPTION
When using this library for our own server (which uses a S3 architecture/ implementation) we ran into a couple of problems. One was that we're using an http:// scheme and the other being we don't have a domain, but rather an IP.
Therefore I created 2 things, a function that replaces the entire config with the config you provide (erlcloud_aws.change_config/1), and 2 cases to create a different URI ([scheme, default_host, port, "/", Host, Path] instead of [scheme, Host, ".", default_host, port, Path]) when a boolean in the default_config record (s3_bucket_after_host, false at default) is set to true.
These changes were made to make this library a bit more flexible to use with your own S3 implementation (like CEPH).