### PR TITLE
ACL Grantee does not contain a nested 'owner'

### DIFF
--- a/src/erlcloud_httpc.erl
+++ b/src/erlcloud_httpc.erl
@@ -53,8 +53,8 @@ request_httpc(URL, Method, Hdrs, <<>>, Timeout, _Config) ->
                                  [{body_format, binary}]));
 request_httpc(URL, Method, Hdrs, Body, Timeout, _Config) ->
     {value,
-     {_, ContentType}, HdrsRest} = lists:keytake(<<"content-type">>, 1, Hdrs),
-    HdrsStr = [{to_list_string(K), to_list_string(V)} || {K, V} <- HdrsRest],
+     {_, ContentType}, _HdrsRest} = lists:keytake("content-type", 1, Hdrs),
+    HdrsStr = [{to_list_string(K), to_list_string(V)} || {K, V} <- Hdrs],
     response_httpc(httpc:request(Method,
                                  {URL, HdrsStr,
                                   to_list_string(ContentType), Body},

--- a/src/erlcloud_httpc.erl
+++ b/src/erlcloud_httpc.erl
@@ -52,12 +52,11 @@ request_httpc(URL, Method, Hdrs, <<>>, Timeout, _Config) ->
                                  [{timeout, Timeout}],
                                  [{body_format, binary}]));
 request_httpc(URL, Method, Hdrs, Body, Timeout, _Config) ->
-    {value,
-     {_, ContentType}, _HdrsRest} = lists:keytake("content-type", 1, Hdrs),
     HdrsStr = [{to_list_string(K), to_list_string(V)} || {K, V} <- Hdrs],
+    {"content-type", ContentType} = lists:keyfind("content-type", 1, HdrsStr),
     response_httpc(httpc:request(Method,
                                  {URL, HdrsStr,
-                                  to_list_string(ContentType), Body},
+                                  ContentType, Body},
                                  [{timeout, Timeout}],
                                  [{body_format, binary}])).
 

--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -983,8 +983,8 @@ encode_grant(Grant) ->
     Grantee = proplists:get_value(grantee, Grant),
     {'Grant',
      [{'Grantee', [{xmlns, ?XMLNS_S3}],
-       [{'ID', [proplists:get_value(id, proplists:get_value(owner, Grantee))]},
-        {'DisplayName', [proplists:get_value(display_name, proplists:get_value(owner, Grantee))]}]},
+       [{'ID', [proplists:get_value(id, Grantee)]},
+        {'DisplayName', [proplists:get_value(display_name, Grantee)]}]},
       {'Permission', [encode_permission(proplists:get_value(permission, Grant))]}]}.
 
 s3_simple_request(Config, Method, Host, Path, Subresource, Params, POSTData, Headers) ->

--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -701,7 +701,7 @@ set_object_acl(BucketName, Key, ACL, Config)
            [{'Owner', [{'ID', [Id]}, {'DisplayName', [DisplayName]}]},
             {'AccessControlList', encode_grants(ACL1)}]},
     XMLText = list_to_binary(xmerl:export_simple([XML], xmerl_xml)),
-    s3_simple_request(Config, put, BucketName, [$/|Key], "acl", [], XMLText, []).
+    s3_simple_request(Config, put, BucketName, [$/|Key], "acl", [], XMLText, [{"content-type", "application/xml"}]).
 
 -spec sign_get(integer(), string(), string(), aws_config()) -> {binary(), string()}.
 sign_get(Expire_time, BucketName, Key, Config)

--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -174,7 +174,7 @@ create_bucket(BucketName, ACL, LocationConstraint, Config)
                    none -> <<>>;
                    Location when Location =:= eu; Location =:= us_west_1 ->
                        LocationName = case Location of eu -> "EU"; us_west_1 -> "us-west-1" end,
-                       XML = {'CreateBucketConfiguration', [{xmlns, ?XMLNS_S3}],
+                       XML = {'CreateBucketConfiguration', [{'xmlns:xsi', ?XMLNS_S3}],
                               [{'LocationConstraint', [LocationName]}]},
                        list_to_binary(xmerl:export_simple([XML], xmerl_xml))
                end,
@@ -391,8 +391,10 @@ extract_contents(Nodes) ->
 extract_user([]) ->
     [];
 extract_user([Node]) ->
-    Attributes = [{id, "ID", text},
-                  {display_name, "DisplayName", optional_text}],
+    Attributes = [{id, "ID", optional_text},
+                  {display_name, "DisplayName", optional_text},
+                  {uri, "URI", optional_text}
+                 ],
     erlcloud_xml:decode(Attributes, Node).
 
 -spec get_bucket_attribute(string(), s3_bucket_attribute_name()) -> term().
@@ -906,7 +908,7 @@ set_bucket_attribute(BucketName, AttributeName, Value, Config)
                 {"acl", ACLXML};
             logging ->
                 LoggingXML = {'BucketLoggingStatus',
-                              [{xmlns, ?XMLNS_S3}],
+                              [{'xmlns:xsi', ?XMLNS_S3}],
                               case proplists:get_bool(enabled, Value) of
                                   true ->
                                       [{'LoggingEnabled',
@@ -925,7 +927,7 @@ set_bucket_attribute(BucketName, AttributeName, Value, Config)
                                 requester -> "Requester";
                                 bucket_owner -> "BucketOwner"
                             end,
-                RPXML = {'RequestPaymentConfiguration', [{xmlns, ?XMLNS_S3}],
+                RPXML = {'RequestPaymentConfiguration', [{'xmlns:xsi', ?XMLNS_S3}],
                          [
                           {'Payer', [PayerName]}
                          ]
@@ -940,7 +942,7 @@ set_bucket_attribute(BucketName, AttributeName, Value, Config)
                                 enabled -> "Enabled";
                                 disabled -> "Disabled"
                             end,
-                VersioningXML = {'VersioningConfiguration', [{xmlns, ?XMLNS_S3}],
+                VersioningXML = {'VersioningConfiguration', [{'xmlns:xsi', ?XMLNS_S3}],
                                  [{'Status', [Status]},
                                   {'MfaDelete', [MFADelete]}]},
                 {"versioning", VersioningXML}
@@ -982,10 +984,19 @@ encode_grants(Grants) ->
 encode_grant(Grant) ->
     Grantee = proplists:get_value(grantee, Grant),
     {'Grant',
-     [{'Grantee', [{xmlns, ?XMLNS_S3}],
-       [{'ID', [proplists:get_value(id, Grantee)]},
-        {'DisplayName', [proplists:get_value(display_name, Grantee)]}]},
+     [encode_grantee(Grantee),
       {'Permission', [encode_permission(proplists:get_value(permission, Grant))]}]}.
+
+encode_grantee(Grantee) ->
+  case proplists:get_value(id, Grantee) of
+    undefined ->
+      {'Grantee', [{'xmlns:xsi', ?XMLNS_S3}, {'xsi:type', "Group"}],
+      [{'URI', [proplists:get_value(uri, Grantee)]}]};
+    Id ->
+      {'Grantee', [{'xmlns:xsi', ?XMLNS_S3}],
+      [{'ID', [Id]},
+       {'DisplayName', [proplists:get_value(display_name, Grantee)]}]}
+  end.
 
 s3_simple_request(Config, Method, Host, Path, Subresource, Params, POSTData, Headers) ->
     case s3_request(Config, Method, Host, Path, Subresource, Params, POSTData, Headers) of

--- a/src/erlcloud_s3.erl
+++ b/src/erlcloud_s3.erl
@@ -993,7 +993,7 @@ encode_grantee(Grantee) ->
       {'Grantee', [{'xmlns:xsi', ?XMLNS_S3}, {'xsi:type', "Group"}],
       [{'URI', [proplists:get_value(uri, Grantee)]}]};
     Id ->
-      {'Grantee', [{'xmlns:xsi', ?XMLNS_S3}],
+      {'Grantee', [{'xmlns:xsi', ?XMLNS_S3}, {'xsi:type', "CanonicalUser"}],
       [{'ID', [Id]},
        {'DisplayName', [proplists:get_value(display_name, Grantee)]}]}
   end.


### PR DESCRIPTION
Noticed this bug when trying to set object acls. The grantee element has no owner sub-element.

Also, added a commit to handle URI based grantees.

http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectGETacl.html