### PR TITLE
Implement a simple manager for multi-part uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ erl_crash.dump
 .edts
 *[#]*[#]
 *[#]*
+
+*.sw[o-p]

--- a/README.md
+++ b/README.md
@@ -90,6 +90,16 @@ For usage information, consult the source code and refer to the API reference at
 - http://docs.aws.amazon.com/AmazonS3/latest/API/Welcome.html
 - http://docs.amazonwebservices.com/AmazonSimpleDB/latest/DeveloperGuide/
 
+## Multi-part uploads ##
+
+A small library is included for managing multi-part uploading of files in a fault-tolerant manner, `erlcloud_s3_multipart`. Example usage: 
+
+```
+erlcloud:start_s3_multipart_sup(). %% starts the multi-part supervisor; intended to be started by one of your supervisors
+erlcloud:put_object_multipart("/path/to/file", "bucket", "key").
+
+```
+
 ## Roadmap ##
 
 v0.8.0

--- a/src/erlcloud.erl
+++ b/src/erlcloud.erl
@@ -1,5 +1,6 @@
 -module(erlcloud).
--export([start/0]).
+
+-export([start/0, start_s3_multipart_sup/0, put_object_multipart/3]).
 
 -define(APP, erlcloud).
 
@@ -8,3 +9,9 @@ start() ->
     {ok, Apps} = application:get_key(?APP, applications),
     [application:start(App) || App <- Apps],
     application:start(?APP).
+
+start_s3_multipart_sup() ->
+    erlcloud_s3_multipart_sup:start_link().
+
+put_object_multipart(FilePath, Bucket, Key) ->
+    erlcloud_s3_multipart_server:put_object(FilePath, Bucket, Key).

--- a/src/erlcloud_s3_multipart_server.erl
+++ b/src/erlcloud_s3_multipart_server.erl
@@ -1,0 +1,129 @@
+-module(erlcloud_s3_multipart_server).
+
+-behaviour(gen_server).
+
+%% API functions
+-export([start_link/0, put_object/3, put_object/4, finish/2]).
+
+%% gen_server callbacks
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
+
+-record(upload, {id, bucket, key, descriptor, from}).
+-record(state, {uploadsInProgress=maps:new()}).
+
+-define(DEFAULT_TIMEOUT, infinity).
+
+%%%===================================================================
+%%% API functions
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Starts the server
+%%
+%% @spec start_link() -> {ok, Pid} | ignore | {error, Error}
+%% @end
+%%--------------------------------------------------------------------
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+-spec put_object(string(), string(), string()) -> ok | {error, any()}.
+put_object(FilePath, Bucket, Key) ->
+   gen_server:call(?MODULE, {upload, {FilePath, Bucket, Key}}, ?DEFAULT_TIMEOUT).
+
+-spec put_object(string(), string(), string(), integer()) -> ok | {error, any()}.
+put_object(FilePath, Bucket, Key, Timeout) ->
+   gen_server:call(?MODULE, {upload, {FilePath, Bucket, Key}}, Timeout).
+
+finish(UploadId, Reply) ->
+    gen_server:cast(?MODULE, {uploaded, UploadId, Reply}).
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+init([]) ->
+    {ok, #state{}}.
+
+handle_call({upload, {FilePath, Bucket, Key}}, From, State) ->
+    {ok, UploadProps} = erlcloud_s3:start_multipart(Bucket, Key),
+    UploadId = proplists:get_value(uploadId, UploadProps),
+
+    {ok, WorkerPid} = erlcloud_s3_multipart_worker_sup:start_upload(FilePath, UploadId, Bucket, Key),
+    MonitorRef = erlang:monitor(process, WorkerPid),
+
+    NewState = State#state{uploadsInProgress=maps:put(MonitorRef, #upload{id=UploadId, bucket=Bucket, key=Key, descriptor=FilePath, from=From}, State#state.uploadsInProgress)},
+
+    {noreply, NewState}.
+
+handle_cast({uploaded, UploadId, Reply}, State) ->
+    UploadsThatJustFinished =    maps:filter(fun(_MonitorRef, Upload) -> Upload#upload.id =:= UploadId end, State#state.uploadsInProgress),
+    UploadsWithoutJustFinished = maps:filter(fun(_MonitorRef, Upload) -> Upload#upload.id =/= UploadId end, State#state.uploadsInProgress),
+
+    lists:foreach(fun({MonitorRef, Upload}) -> 
+        erlang:demonitor(MonitorRef),
+        gen_server:reply(Upload#upload.from, Reply)
+    end, maps:to_list(UploadsThatJustFinished)),
+
+    NewState = State#state{uploadsInProgress=UploadsWithoutJustFinished},
+
+    {noreply, NewState}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Handling all non call/cast messages
+%%
+%% @spec handle_info(Info, State) -> {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, State}
+%% @end
+%%--------------------------------------------------------------------
+
+
+handle_info({'DOWN', MonitorRef, process, _Object, Reason}, State) ->
+    case maps:is_key(MonitorRef, State#state.uploadsInProgress) of
+        false -> {noreply, State};
+        true -> 
+            Upload = maps:get(MonitorRef, State#state.uploadsInProgress),
+            erlcloud_s3:abort_multipart(Upload#upload.bucket, Upload#upload.key, Upload#upload.id),
+            gen_server:reply(Upload#upload.from, {error, Reason}),
+
+            NewState = State#state{uploadsInProgress=maps:remove(MonitorRef, State#state.uploadsInProgress)},
+
+            {noreply, NewState}
+    end.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% This function is called by a gen_server when it is about to
+%% terminate. It should be the opposite of Module:init/1 and do any
+%% necessary cleaning up. When it returns, the gen_server terminates
+%% with Reason. The return value is ignored.
+%%
+%% @spec terminate(Reason, State) -> void()
+%% @end
+%%--------------------------------------------------------------------
+terminate(_Reason, _State) ->
+    ok.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Convert process state when code is changed
+%%
+%% @spec code_change(OldVsn, State, Extra) -> {ok, NewState}
+%% @end
+%%--------------------------------------------------------------------
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================

--- a/src/erlcloud_s3_multipart_sup.erl
+++ b/src/erlcloud_s3_multipart_sup.erl
@@ -1,0 +1,28 @@
+-module(erlcloud_s3_multipart_sup).
+
+-behaviour(supervisor).
+
+-export([start_link/0]).
+
+-export([init/1]).
+
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+init([]) ->
+    {ok, {{one_for_all, 5, 10}, [
+
+        #{id => server,
+          start => {erlcloud_s3_multipart_server, start_link, []},
+          restart => permanent,
+          type => worker,
+          modules => [erlcloud_s3_multipart_server]
+         },
+
+        #{id => worker_sup,
+          start => {erlcloud_s3_multipart_worker_sup, start_link, []},
+          restart => permanent,
+          type => supervisor,
+          modules => [erlcloud_s3_multipart_worker_sup]
+         }
+    ]}}.

--- a/src/erlcloud_s3_multipart_worker.erl
+++ b/src/erlcloud_s3_multipart_worker.erl
@@ -1,0 +1,208 @@
+-module(erlcloud_s3_multipart_worker).
+
+-behaviour(gen_server).
+
+%% API functions
+-export([start_link/4, calculate_filesize_parts/1]).
+
+%% gen_server callbacks
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
+
+-record(state, {file_path, bucket, key, uploadid, file_descriptor, parts_completed, etags, number_of_parts}).
+-define(SPLIT_BY_BYTES, (10*1024*1024)).
+
+%%%===================================================================
+%%% API functions
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @doc
+%% Starts the server
+%%
+%% @spec start_link() -> {ok, Pid} | ignore | {error, Error}
+%% @end
+%%--------------------------------------------------------------------
+start_link(FilePath, UploadId, Bucket, Key) ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [FilePath, UploadId, Bucket, Key], []).
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Initializes the server
+%%
+%% @spec init(Args) -> {ok, State} |
+%%                     {ok, State, Timeout} |
+%%                     ignore |
+%%                     {stop, Reason}
+%% @end
+%%--------------------------------------------------------------------
+init([FilePath, UploadId, Bucket, Key]) ->
+
+    NumberOfParts=calculate_filesize_parts(FilePath),
+
+    {ok, FileDescriptor} = file:open(FilePath, [read, {encoding, utf8}]),
+
+    gen_server:cast(self(), upload_next_piece),
+
+    {ok, #state{file_path=FilePath,
+                file_descriptor=FileDescriptor, 
+                bucket=Bucket, 
+                key=Key, 
+                uploadid=UploadId, 
+                parts_completed=0, 
+                etags=[],
+                number_of_parts=NumberOfParts}}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Handling call messages
+%%
+%% @spec handle_call(Request, From, State) ->
+%%                                   {reply, Reply, State} |
+%%                                   {reply, Reply, State, Timeout} |
+%%                                   {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, Reply, State} |
+%%                                   {stop, Reason, State}
+%% @end
+%%--------------------------------------------------------------------
+handle_call(_Request, _From, State) ->
+    Reply = ok,
+    {reply, Reply, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Handling cast messages
+%%
+%% @spec handle_cast(Msg, State) -> {noreply, State} |
+%%                                  {noreply, State, Timeout} |
+%%                                  {stop, Reason, State}
+%% @end
+%%--------------------------------------------------------------------
+handle_cast(upload_next_piece, State) when State#state.parts_completed+1 =< State#state.number_of_parts ->
+
+    CurrentPartNumber = State#state.parts_completed+1,
+
+    UploadId = State#state.uploadid,
+    FileDescriptor = State#state.file_descriptor,
+    ReadResult = file:read(FileDescriptor, ?SPLIT_BY_BYTES),
+
+    case ReadResult of 
+        {ok, Data} -> 
+            
+            UploadResult = erlcloud_s3:upload_part(State#state.bucket, State#state.key, UploadId, CurrentPartNumber, Data),
+
+            case UploadResult of
+                {ok, UploadResultProps} -> 
+
+                    ETag = proplists:get_value(etag, UploadResultProps),
+                    ETagWithoutQuotes = string:sub_string(ETag, 2, length(ETag)-1),
+
+                    gen_server:cast(self(), upload_next_piece),
+                    NewState = State#state{parts_completed=CurrentPartNumber, etags=[{CurrentPartNumber, ETagWithoutQuotes}|State#state.etags]},
+                    {noreply, NewState};
+
+                SomethingElse ->
+
+                    Error = {error, {uploading, SomethingElse}},
+                    abort(State, Error),
+
+                    {stop, Error, State}
+            end;
+
+        SomethingElse -> 
+            
+            Error = {error, {reading, SomethingElse}},
+            abort(State, Error),
+
+            {stop, Error, State}
+    end;
+
+handle_cast(upload_next_piece, State) when State#state.parts_completed+1 > State#state.number_of_parts ->
+
+    FileDescriptor = State#state.file_descriptor,
+
+    ETags = lists:reverse(State#state.etags),
+    erlcloud_s3:complete_multipart(State#state.bucket, State#state.key, State#state.uploadid, ETags),
+    file:close(FileDescriptor),
+    erlcloud_s3_multipart_server:finish(State#state.uploadid, ok),
+
+    {stop, normal, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Handling all non call/cast messages
+%%
+%% @spec handle_info(Info, State) -> {noreply, State} |
+%%                                   {noreply, State, Timeout} |
+%%                                   {stop, Reason, State}
+%% @end
+%%--------------------------------------------------------------------
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% This function is called by a gen_server when it is about to
+%% terminate. It should be the opposite of Module:init/1 and do any
+%% necessary cleaning up. When it returns, the gen_server terminates
+%% with Reason. The return value is ignored.
+%%
+%% @spec terminate(Reason, State) -> void()
+%% @end
+%%--------------------------------------------------------------------
+terminate(_Reason, _State) ->
+    ok.
+
+%%--------------------------------------------------------------------
+%% @private
+%% @doc
+%% Convert process state when code is changed
+%%
+%% @spec code_change(OldVsn, State, Extra) -> {ok, NewState}
+%% @end
+%%--------------------------------------------------------------------
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================
+
+abort(State, Reason) ->
+    erlcloud_s3:abort_multipart(State#state.bucket, State#state.key, State#state.uploadid),
+    file:close(State#state.file_descriptor),
+    erlcloud_s3_multipart_server:finish(State#state.uploadid, Reason).
+
+calculate_filesize_parts(FilePath) ->
+    {ok, FileInfo} = file:read_file_info(FilePath),
+    FileSize = element(2, FileInfo),
+
+    case FileSize of 
+        undefined -> {stop, undefinedsize};
+        Size -> 
+
+            %% Poor man's ceil()
+            NumberOfPartsWithoutRemainder = Size div ?SPLIT_BY_BYTES,
+            NumberOfPartsRemainder = Size rem ?SPLIT_BY_BYTES,
+            NumberOfPartsFactor = case NumberOfPartsRemainder of
+                0 -> 0;
+                _ -> 1
+            end,
+
+            NumberOfPartsWithoutRemainder+NumberOfPartsFactor
+
+    end.

--- a/src/erlcloud_s3_multipart_worker_sup.erl
+++ b/src/erlcloud_s3_multipart_worker_sup.erl
@@ -1,0 +1,31 @@
+-module(erlcloud_s3_multipart_worker_sup).
+
+-behaviour(supervisor).
+
+-export([start_link/0, start_upload/4]).
+
+-export([init/1]).
+
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+%% Starts empty, supervises multi-part uploads
+
+init([]) -> 
+    {ok, {{simple_one_for_one, 0, 1}, [
+        #{id => worker,
+          start => {erlcloud_s3_multipart_worker, start_link, []},
+          restart => temporary,
+          type => worker,
+          modules => [erlcloud_s3_multipart_worker]
+         }
+    ]}}.
+
+start_upload(FilePath, UploadId, Bucket, Key) -> 
+    StartChildResult = supervisor:start_child(?MODULE, [FilePath, UploadId, Bucket, Key]),
+
+    case StartChildResult of 
+        {ok, ChildPid} -> {ok, ChildPid};
+        {ok, ChildPid, _Info} -> {ok, ChildPid};
+        {error, Error} -> {error, Error}
+    end.


### PR DESCRIPTION
The existing API for consumers of this library for multi-part uploads is tedious to use, so I made a wrapper for it that will handle the lifecycle of calling `start_multipart`, then calculating the number of pieces necessary, then for each piece calling `upload_part`, accumulating the ETags, and finally calling `complete_multipart`, or calling `abort_multipart` if an error occurs. 

Notes:

* Currently uploads one at a time (part one, then part two, then part three). Could be done in parallel. 
* Currently split parts exactly on 10MB chunks. The smallest part size is 5MB, and it looks like the largest part size is 500MB. It could support variable numbers of parts. Files less than the smallest part size (5MB) are trivially supported. 
* Currently ONLY uses the `default_config()` AWS config and default HTTP options. I was happy to see the default configuration has a timeout, but with a default value of 10,000 ms, and a static chunk size of 10 MB, that means your uplink to S3 must be at least 1 megabyte per second, else uploading a ten megabyte file will time out. 
* Each file that is to be uploaded is allocated a unique upload ID by S3, and each upload ID is assigned a single worker by this library. The supervision strategy for the workers is `temporary`, so uploads will not be retried per se, but there is a `gen_server` that `monitor()`'s the workers as they are spawned, so that crashing workers should be cleaned up. This is important because partial uploads consume resources on S3 and you will be charged for partial uploads unless you clean up after them by calling `abort_multipart`.
* The interface to this library is a `gen_server:call`, i.e. synchronous. It might be nice to have a `cast` as well so that users can "fire-and-forget" an upload. 