### PR TITLE
erlcloud_ses: add support for MessageRejected errors

### DIFF
--- a/src/erlcloud_ses.erl
+++ b/src/erlcloud_ses.erl
@@ -935,6 +935,7 @@ decode_error_code("InvalidParameterCombination") -> invalid_parameter_combinatio
 decode_error_code("InvalidParameterValue") -> invalid_parameter_value;
 decode_error_code("InvalidQueryParameter") -> invalid_query_parameter;
 decode_error_code("MalformedQueryString") -> malformed_query_string;
+decode_error_code("MessageRejected") -> message_rejected;
 decode_error_code("MissingAction") -> missing_action;
 decode_error_code("MissingAuthenticationToken") -> missing_authentication_token;
 decode_error_code("MissingParameter") -> missing_parameter;


### PR DESCRIPTION
I missed this error code in my original implementation (mentioned [here](http://docs.aws.amazon.com/ses/latest/DeveloperGuide/ses-errors.html) in the AWS SES docs). I noticed it in a testing environment where SES wasn't configured. This makes erlcloud_ses return the error gracefully, instead of with an unceremonious `function_clause` error.