### PR TITLE
Function mismatch with httpc

### DIFF
--- a/src/erlcloud_httpc.erl
+++ b/src/erlcloud_httpc.erl
@@ -46,7 +46,14 @@ request(URL, Method, Hdrs, Body, Timeout,
 request_lhttpc(URL, Method, Hdrs, Body, Timeout, _Config) ->
     lhttpc:request(URL, Method, Hdrs, Body, Timeout, []).
 
-request_httpc(URL, Method, Hdrs, <<>>, Timeout, _Config) ->
+%% Guard clause protects against empty bodied requests from being
+%% unable to find a matching httpc:request call.
+request_httpc(URL, Method, Hdrs, <<>>, Timeout, _Config) 
+    when (Method =:= options) orelse 
+         (Method =:= get) orelse 
+         (Method =:= head) orelse 
+         (Method =:= delete) orelse 
+         (Method =:= trace) ->
     HdrsStr = [{to_list_string(K), to_list_string(V)} || {K, V} <- Hdrs],
     response_httpc(httpc:request(Method, {URL, HdrsStr},
                                  [{timeout, Timeout}],


### PR DESCRIPTION
Tuple mismatch on the 2nd param of httpc:request for puts/posts.  Mirrored the guard clause that exists in otp/httpc.erl