### PR TITLE
Removed deprecated erlang:now.

### DIFF
--- a/src/erlcloud_sdb.erl
+++ b/src/erlcloud_sdb.erl
@@ -333,7 +333,7 @@ extract_item(Item) ->
     ].
 
 sdb_request(Config, Action, Params) ->
-    case sdb_request_with_retry(Config, Action, Params, 1, ?SDB_TIMEOUT, erlang:now()) of
+    case sdb_request_with_retry(Config, Action, Params, 1, ?SDB_TIMEOUT, erlang:monotonic_time()) of
         {ok, {Doc, Metadata}} ->
             {Doc, Metadata};
         {error, Error} ->
@@ -346,7 +346,7 @@ sdb_request_with_retry(Config, Action, Params, Try, Timeout, StartTime) ->
             {ok, {Doc, Metadata}};
         {error, {http_error, 503, _StatusLine, _Body}} ->
             %% Convert from microseconds to milliseconds
-            Waited = timer:now_diff(erlang:now(), StartTime) / 1000.0,
+            Waited = (erlang:monotonic_time() - StartTime) / 1000000.0,
             case Waited of
                 _TooLong when Waited > Timeout ->
                     {error, retry_timeout};

--- a/src/erlcloud_sdb.erl
+++ b/src/erlcloud_sdb.erl
@@ -346,7 +346,7 @@ sdb_request_with_retry(Config, Action, Params, Try, Timeout, StartTime) ->
             {ok, {Doc, Metadata}};
         {error, {http_error, 503, _StatusLine, _Body}} ->
             %% Convert from microseconds to milliseconds
-            Waited = timer:diff_now(os:timestamp() - StartTime) / 1000000.0,
+            Waited = timer:now_diff(os:timestamp() - StartTime) / 1000000.0,
             case Waited of
                 _TooLong when Waited > Timeout ->
                     {error, retry_timeout};

--- a/src/erlcloud_sdb.erl
+++ b/src/erlcloud_sdb.erl
@@ -333,7 +333,7 @@ extract_item(Item) ->
     ].
 
 sdb_request(Config, Action, Params) ->
-    case sdb_request_with_retry(Config, Action, Params, 1, ?SDB_TIMEOUT, erlang:monotonic_time()) of
+    case sdb_request_with_retry(Config, Action, Params, 1, ?SDB_TIMEOUT, os:timestamp()) of
         {ok, {Doc, Metadata}} ->
             {Doc, Metadata};
         {error, Error} ->
@@ -346,7 +346,7 @@ sdb_request_with_retry(Config, Action, Params, Try, Timeout, StartTime) ->
             {ok, {Doc, Metadata}};
         {error, {http_error, 503, _StatusLine, _Body}} ->
             %% Convert from microseconds to milliseconds
-            Waited = (erlang:monotonic_time() - StartTime) / 1000000.0,
+            Waited = timer:diff_now(os:timestamp() - StartTime) / 1000000.0,
             case Waited of
                 _TooLong when Waited > Timeout ->
                     {error, retry_timeout};


### PR DESCRIPTION
erlang:now is deprecated in Erlang 18 (http://www.erlang.org/news/88), so I replaced it with erlang:monotonic_time in accordance to the Erlang user guide (http://www.erlang.org/doc/apps/erts/time_correction.html#Dos_and_Donts)