### PR TITLE
Erlang 18 compatibility

### DIFF
--- a/src/erlcloud_sdb.erl
+++ b/src/erlcloud_sdb.erl
@@ -333,7 +333,7 @@ extract_item(Item) ->
     ].
 
 sdb_request(Config, Action, Params) ->
-    case sdb_request_with_retry(Config, Action, Params, 1, ?SDB_TIMEOUT, erlang:now()) of
+    case sdb_request_with_retry(Config, Action, Params, 1, ?SDB_TIMEOUT, os:timestamp()) of
         {ok, {Doc, Metadata}} ->
             {Doc, Metadata};
         {error, Error} ->
@@ -346,7 +346,7 @@ sdb_request_with_retry(Config, Action, Params, Try, Timeout, StartTime) ->
             {ok, {Doc, Metadata}};
         {error, {http_error, 503, _StatusLine, _Body}} ->
             %% Convert from microseconds to milliseconds
-            Waited = timer:now_diff(erlang:now(), StartTime) / 1000.0,
+            Waited = timer:now_diff(os:timestamp(), StartTime) / 1000.0,
             case Waited of
                 _TooLong when Waited > Timeout ->
                     {error, retry_timeout};


### PR DESCRIPTION
Changed erlang:now() (deprecated in Erlang 18) to os:timestamp.
This way it should be compatible with Erlang 18 as well as older versions.
(Old PR: https://github.com/gleber/erlcloud/pull/212)