### PR TITLE
Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 language: erlang
 otp_release:
   - R16B03-1
+  - 17.5
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+sudo: false
+language: erlang
+otp_release:
+  - R16B03-1
+branches:
+  only:
+    - master
+script: make eunit

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # erlcloud: Cloud Computing APIs For Erlang #
 
-This is version 0.8.0.  The API is subject to change.
+[![Build Status](https://secure.travis-ci.org/alertlogic/erlcloud.png?branch=master)](http://travis-ci.org/alertlogic/erlcloud)
 
 Service APIs implemented:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # erlcloud: Cloud Computing APIs For Erlang #
 
-[![Build Status](https://secure.travis-ci.org/alertlogic/erlcloud.png?branch=master)](http://travis-ci.org/alertlogic/erlcloud)
+[![Build Status](https://secure.travis-ci.org/gleber/erlcloud.png?branch=master)](http://travis-ci.org/gleber/erlcloud)
 
 Service APIs implemented:
 


### PR DESCRIPTION
Introduce use of Travis into the project alike it was done in our fork.

to make it working @ransomr need to register & allow access For Travis to gleber/erlcloud. Please follow http://docs.travis-ci.com/user/getting-started/.

Goal:
this will make auto running `make eunit` upon every PR against two Erlang versions. 