### PR TITLE
erlcloud_aws changes, merging code from alertlogic repo

### DIFF
--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -462,16 +462,16 @@ get_service_status(ServiceNames) when is_list(ServiceNames) ->
 
 get_filtered_statuses(ServiceNames, Statuses) ->
     lists:filter(
-        fun(S)-> 
+        fun(S)->
             lists:any(
-                fun(InputService)-> 
+                fun(InputService)->
                     ServiceNameBin = list_to_binary(InputService),
                     ServiceNameLen = byte_size(ServiceNameBin),
-                    case proplists:get_value(<<"service">>, S) of 
+                    case proplists:get_value(<<"service">>, S) of
                         <<ServiceNameBin:ServiceNameLen/binary, _/binary>> -> true;
                         _ -> false
                     end
-                end, 
-            ServiceNames)
+                end,
+                ServiceNames)
         end,
-    Statuses).
+        Statuses).

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -203,11 +203,11 @@ default_config() ->
     case get(aws_config) of
         undefined ->
             AccessKeyId = case os:getenv("AWS_ACCESS_KEY_ID") of
-                              false -> "";
+                              false -> undefined;
                               AKI -> AKI
                           end,
             SecretAccessKey = case os:getenv("AWS_SECRET_ACCESS_KEY") of
-                                  false -> "";
+                                  false -> undefined;
                                   SAC -> SAC
                               end,
             #aws_config{access_key_id = AccessKeyId,

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -13,7 +13,8 @@
          http_headers_body/1,
          request_to_return/1,
          sign_v4_headers/5,
-         sign_v4/8]).
+         sign_v4/8,
+         get_service_status/1]).
 
 -include("erlcloud.hrl").
 -include_lib("erlcloud/include/erlcloud_aws.hrl").
@@ -429,3 +430,27 @@ authorization(Config, CredentialScope, SignedHeaders, Signature) ->
      " Credential=", Config#aws_config.access_key_id, $/, CredentialScope, $,,
      " SignedHeaders=", SignedHeaders, $,,
      " Signature=", Signature].
+
+%% This function fetches http://status.aws.amazon.com/data.json
+%% and examine "current" section for on going AWS issues/failures.
+-spec get_service_status(string()) -> ok | list().
+get_service_status(ServiceName) when is_list(ServiceName) ->
+    {ok, Json} = aws_request_form(
+        get, "http", "status.aws.amazon.com", undefined, 
+        "/data.json", "", [], default_config()),
+    ServiceNameBin = list_to_binary(ServiceName),
+    ServiceNameLen = byte_size(ServiceNameBin),
+    
+    ServiceStatuses = lists:filter(
+        fun(S)-> 
+            case proplists:get_value(<<"service">>, S) of 
+                <<ServiceNameBin:ServiceNameLen/binary, _/binary>> -> true;
+                _ -> false
+            end
+        end,
+    proplists:get_value(<<"current">>, jsx:decode(Json))),
+        
+    case ServiceStatuses of
+        [] -> ok;
+        ReturnStatuses -> ReturnStatuses
+    end.

--- a/src/erlcloud_aws.erl
+++ b/src/erlcloud_aws.erl
@@ -4,18 +4,21 @@
          aws_request_xml/5, aws_request_xml/6, aws_request_xml/7, aws_request_xml/8,
          aws_request2/7,
          aws_request_xml2/5, aws_request_xml2/7,
-         aws_request_xml4/6,aws_request_xml4/8,
+         aws_request4/8,
+         aws_request_xml4/6, aws_request_xml4/8,
+         aws_region_from_host/1,
          aws_request_form/8,
          param_list/2, default_config/0, update_config/1,
          configure/1, format_timestamp/1,
          http_headers_body/1,
          request_to_return/1,
-         sign_v4/5]).
+         sign_v4_headers/5,
+         sign_v4/8]).
 
 -include("erlcloud.hrl").
 -include_lib("erlcloud/include/erlcloud_aws.hrl").
 
--record(metadata_credentials, 
+-record(metadata_credentials,
         {access_key_id :: string(),
          secret_access_key :: string(),
          security_token=undefined :: string(),
@@ -91,15 +94,23 @@ aws_request2_no_update(Method, Protocol, Host, Port, Path, Params, #aws_config{}
                         undefined -> [];
                         Token -> [{"SecurityToken", Token}]
                     end),
-    
+
     QueryToSign = erlcloud_http:make_query_string(QParams),
     RequestToSign = [string:to_upper(atom_to_list(Method)), $\n,
                      string:to_lower(Host), $\n, Path, $\n, QueryToSign],
     Signature = base64:encode(erlcloud_util:sha_mac(Config#aws_config.secret_access_key, RequestToSign)),
-    
+
     Query = [QueryToSign, "&Signature=", erlcloud_http:url_encode(Signature)],
-    
+
     aws_request_form(Method, Protocol, Host, Port, Path, Query, [], Config).
+
+aws_region_from_host(Host) ->
+    case string:tokens(Host, ".") of
+        [_, Value, _, _] ->
+            Value;
+        _ ->
+            "us-east-1"
+    end.
 
 aws_request4(Method, Protocol, Host, Port, Path, Params, Service, Config) ->
     case update_config(Config) of
@@ -110,24 +121,20 @@ aws_request4(Method, Protocol, Host, Port, Path, Params, Service, Config) ->
     end.
 
 aws_request4_no_update(Method, Protocol, Host, Port, Path, Params, Service, #aws_config{} = Config) ->
-    QueryToSign = erlcloud_http:make_query_string(Params),
-    
-    Headers = [{"host", Host}],
-
-    Region =
-        case string:tokens(Host, ".") of
-            [_, Value, _, _] ->
-                Value;
-            _ ->
-                "us-east-1"
-        end,
+    Query = erlcloud_http:make_query_string(Params),
+    Region = aws_region_from_host(Host),
 
     SignedHeaders = case Method of
-        get -> sign_v4(Method, Config, Headers, Params, "", Region, Service);
-        post -> sign_v4(Method, Config, Headers, "", QueryToSign, Region, Service)
-    end,
+                        post ->
+                            sign_v4(Method, Path, Config,
+                                    [{"host", Host}], list_to_binary(Query),
+                                    Region, Service, []);
+                        get ->
+                            sign_v4(Method, Path, Config, [{"host", Host}],
+                                    [], Region, Service, Params)
+                    end,
 
-    aws_request_form(Method, Protocol, Host, Port, Path, QueryToSign, SignedHeaders, Config).
+    aws_request_form(Method, Protocol, Host, Port, Path, Query, SignedHeaders, Config).
 
 
 -spec aws_request_form(Method :: atom(), Protocol :: undefined | string(), Host :: string(),
@@ -138,12 +145,12 @@ aws_request_form(Method, Protocol, Host, Port, Path, Form, Headers, Config) ->
         undefined -> "https://";
         _ -> [Protocol, "://"]
     end,
-    
+
     URL = case Port of
         undefined -> [UProtocol, Host, Path];
         _ -> [UProtocol, Host, $:, port_to_str(Port), Path]
     end,
-    
+
     %% Note: httpc MUST be used with {timeout, timeout()} option
     %%       Many timeout related failures is observed at prod env
     %%       when library is used in 24/7 manner
@@ -155,11 +162,11 @@ aws_request_form(Method, Protocol, Host, Port, Path, Form, Headers, Config) ->
                   Req, get, Headers, <<>>, Config#aws_config.timeout, Config);
             _ ->
                 erlcloud_httpc:request(
-                  lists:flatten(URL), Method, 
+                  lists:flatten(URL), Method,
                   [{<<"content-type">>, <<"application/x-www-form-urlencoded; charset=utf-8">>} | Headers],
                   list_to_binary(Form), Config#aws_config.timeout, Config)
         end,
-    
+
     http_body(Response).
 
 param_list([], _Key) -> [];
@@ -194,15 +201,23 @@ format_timestamp({{Yr, Mo, Da}, {H, M, S}}) ->
 default_config() ->
     case get(aws_config) of
         undefined ->
-            #aws_config{access_key_id=os:getenv("AWS_ACCESS_KEY_ID"),
-                        secret_access_key=os:getenv("AWS_SECRET_ACCESS_KEY")};
+            AccessKeyId = case os:getenv("AWS_ACCESS_KEY_ID") of
+                              false -> "";
+                              AKI -> AKI
+                          end,
+            SecretAccessKey = case os:getenv("AWS_SECRET_ACCESS_KEY") of
+                                  false -> "";
+                                  SAC -> SAC
+                              end,
+            #aws_config{access_key_id = AccessKeyId,
+                        secret_access_key = SecretAccessKey};
         Config ->
             Config
     end.
 
 -spec update_config(aws_config()) -> {ok, aws_config()} | {error, term()}.
 update_config(#aws_config{access_key_id = KeyId} = Config)
-  when is_list(KeyId) ->
+  when is_list(KeyId), KeyId /= [] ->
     %% In order to support caching of the aws_config, we could store the expiration_time
     %% and check it here. If it is about to expire (within 5 minutes is what boto uses)
     %% then we should get the new config.
@@ -243,8 +258,8 @@ get_metadata_credentials(Config) ->
 timestamp_to_gregorian_seconds(Timestamp) ->
     {ok, [Yr, Mo, Da, H, M, S], []} = io_lib:fread("~d-~d-~dT~d:~d:~dZ", binary_to_list(Timestamp)),
     calendar:datetime_to_gregorian_seconds({{Yr, Mo, Da}, {H, M, S}}).
-    
--spec get_credentials_from_metadata(aws_config()) 
+
+-spec get_credentials_from_metadata(aws_config())
                                    -> {ok, #metadata_credentials{}} | {error, term()}.
 get_credentials_from_metadata(Config) ->
     %% TODO this function should retry on errors getting credentials
@@ -260,7 +275,7 @@ get_credentials_from_metadata(Config) ->
             [Role | _] = binary:split(Body, <<$\n>>),
             case http_body(
                    erlcloud_httpc:request(
-                     "http://169.254.169.254/latest/meta-data/iam/security-credentials/" ++ 
+                     "http://169.254.169.254/latest/meta-data/iam/security-credentials/" ++
                          binary_to_list(Role),
                      get, [], <<>>, Config#aws_config.timeout, Config)) of
                 {error, Reason} ->
@@ -283,7 +298,7 @@ port_to_str(Port) when is_integer(Port) ->
 port_to_str(Port) when is_list(Port) ->
     Port.
 
--spec http_body({ok, tuple()} | {error, term()}) 
+-spec http_body({ok, tuple()} | {error, term()})
                -> {ok, binary()} | {error, tuple()}.
 %% Extract the body and do error handling on the return of a httpc:request call.
 http_body(Return) ->
@@ -295,10 +310,10 @@ http_body(Return) ->
     end.
 
 -type headers() :: [{string(), string()}].
--spec http_headers_body({ok, tuple()} | {error, term()}) 
+-spec http_headers_body({ok, tuple()} | {error, term()})
                        -> {ok, {headers(), binary()}} | {error, tuple()}.
 %% Extract the headers and body and do error handling on the return of a httpc:request call.
-http_headers_body({ok, {{OKStatus, _StatusLine}, Headers, Body}}) 
+http_headers_body({ok, {{OKStatus, _StatusLine}, Headers, Body}})
   when OKStatus >= 200, OKStatus =< 299 ->
     {ok, {Headers, Body}};
 http_headers_body({ok, {{Status, StatusLine}, _Headers, Body}}) ->
@@ -307,12 +322,12 @@ http_headers_body({error, Reason}) ->
     {error, {socket_error, Reason}}.
 
 %% Convert an aws_request record to return value as returned by http_headers_body
-request_to_return(#aws_request{response_type = ok, 
-                               response_headers = Headers, 
+request_to_return(#aws_request{response_type = ok,
+                               response_headers = Headers,
                                response_body = Body}) ->
-    {ok, {Headers, Body}};
+    {ok, {[ {string:to_lower(H), V} || {H, V} <- Headers ], Body}};
 request_to_return(#aws_request{response_type = error,
-                               error_type = httpc, 
+                               error_type = httpc,
                                httpc_error_reason = Reason}) ->
     {error, {socket_error, Reason}};
 request_to_return(#aws_request{response_type = error,
@@ -323,43 +338,42 @@ request_to_return(#aws_request{response_type = error,
     {error, {http_error, Status, StatusLine, Body}}.
 
 %% http://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
-%% TODO additional parameters - currently only supports what is needed for DynamoDB
--spec sign_v4(aws_config(), headers(), binary(), string(), string()) -> headers().
-sign_v4(Config, Headers, Payload, Region, Service) ->
-    sign_v4(post, Config, Headers, [], Payload, Region, Service).
+-spec sign_v4_headers(aws_config(), headers(), binary(), string(), string()) -> headers().
+sign_v4_headers(Config, Headers, Payload, Region, Service) ->
+    sign_v4(post, "/", Config, Headers, Payload, Region, Service, []).
 
--spec sign_v4(atom(), aws_config(), headers(), string(), iodata(), string(), string()) -> headers().
-sign_v4(Method, Config, Headers, QueryParams, Payload, Region, Service) ->
+-spec sign_v4(atom(), list(), aws_config(), headers(), binary(), string(), string(), list()) -> headers().
+sign_v4(Method, Uri, Config, Headers, Payload, Region, Service, QueryParams) ->
     Date = iso_8601_basic_time(),
-    Headers1 = [{"x-amz-date", Date} | Headers],
+    PayloadHash = hash_encode(Payload),
+    Headers1 = [{"x-amz-content-sha256", PayloadHash}, {"x-amz-date", Date} | Headers],
     Headers2 = case Config#aws_config.security_token of
                    undefined -> Headers1;
                    Token -> [{"x-amz-security-token", Token} | Headers1]
                end,
-    CanonicalQueryString = canonical_query_string(QueryParams),
-    MethodString = string:to_upper(atom_to_list(Method)),
-    {Request, SignedHeaders} = canonical_request(MethodString, "/", CanonicalQueryString, Headers2, Payload),
+    {Request, SignedHeaders} = canonical_request(Method, Uri, QueryParams, Headers2, PayloadHash),
     CredentialScope = credential_scope(Date, Region, Service),
     ToSign = to_sign(Date, CredentialScope, Request),
     SigningKey = signing_key(Config, Date, Region, Service),
     Signature = base16(erlcloud_util:sha256_mac( SigningKey, ToSign)),
     Authorization = authorization(Config, CredentialScope, SignedHeaders, Signature),
     [{"Authorization", lists:flatten(Authorization)} | Headers2].
-    
+
 iso_8601_basic_time() ->
     {{Year,Month,Day},{Hour,Min,Sec}} = calendar:now_to_universal_time(os:timestamp()),
     lists:flatten(io_lib:format(
                     "~4.10.0B~2.10.0B~2.10.0BT~2.10.0B~2.10.0B~2.10.0BZ",
                     [Year, Month, Day, Hour, Min, Sec])).
 
-canonical_request(Method, CanonicalURI, CanonicalQueryString, Headers, Payload) ->
+canonical_request(Method, CanonicalURI, QParams, Headers, PayloadHash) ->
     {CanonicalHeaders, SignedHeaders} = canonical_headers(Headers),
-    {[Method, $\n,
+    CanonicalQueryString = canonical_query_string(QParams),
+    {[string:to_upper(atom_to_list(Method)), $\n,
       CanonicalURI, $\n,
       CanonicalQueryString, $\n,
       CanonicalHeaders, $\n,
       SignedHeaders, $\n,
-      hash_encode(Payload)],
+      PayloadHash],
      SignedHeaders}.
 
 canonical_headers(Headers) ->
@@ -395,13 +409,13 @@ base16(Data) ->
 credential_scope(Date, Region, Service) ->
     DateOnly = string:left(Date, 8),
     [DateOnly, $/, Region, $/, Service, "/aws4_request"].
-    
+
 to_sign(Date, CredentialScope, Request) ->
     ["AWS4-HMAC-SHA256\n",
      Date, $\n,
      CredentialScope, $\n,
      hash_encode(Request)].
-    
+
 signing_key(Config, Date, Region, Service) ->
     %% TODO cache the signing key so we don't have to recompute for every request
     DateOnly = string:left(Date, 8),
@@ -409,7 +423,7 @@ signing_key(Config, Date, Region, Service) ->
     KRegion = erlcloud_util:sha256_mac( KDate, Region),
     KService = erlcloud_util:sha256_mac( KRegion, Service),
     erlcloud_util:sha256_mac( KService, "aws4_request").
-    
+
 authorization(Config, CredentialScope, SignedHeaders, Signature) ->
     ["AWS4-HMAC-SHA256"
      " Credential=", Config#aws_config.access_key_id, $/, CredentialScope, $,,

--- a/src/erlcloud_cloudtrail.erl
+++ b/src/erlcloud_cloudtrail.erl
@@ -179,15 +179,7 @@ headers(Config, Operation, _Params, Body, Service) ->
                {"host", Config#aws_config.cloudtrail_host},
                {"x-amz-target", Operation}
                ],
-    Region =
-        case string:tokens(Config#aws_config.cloudtrail_host, ".") of
-            [_, Value, _, _] ->
-                Value;
-            _ ->
-                "us-east-1"
-        end,
-    
-    erlcloud_aws:sign_v4(Config, Headers, Body, Region, Service).
+    erlcloud_aws:sign_v4_headers(Config, Headers, Body, erlcloud_aws:aws_region_from_host(Config#aws_config.cloudtrail_host), Service).
 
 
 default_config() -> erlcloud_aws:default_config().

--- a/src/erlcloud_ddb_impl.erl
+++ b/src/erlcloud_ddb_impl.erl
@@ -256,14 +256,8 @@ client_error(Body, DDBError) ->
 headers(Config, Operation, Body) ->
     Headers = [{"host", Config#aws_config.ddb_host},
                {"x-amz-target", Operation}],
-    Region =
-        case string:tokens(Config#aws_config.ddb_host, ".") of
-            [_, Value, _, _] ->
-                Value;
-            _ ->
-                "us-east-1"
-        end,
-    erlcloud_aws:sign_v4(Config, Headers, Body, Region, "dynamodb").
+
+    erlcloud_aws:sign_v4_headers(Config, Headers, Body, erlcloud_aws:aws_region_from_host(Config#aws_config.ddb_host), "dynamodb").
 
 url(#aws_config{ddb_scheme = Scheme, ddb_host = Host} = Config) ->
     lists:flatten([Scheme, Host, port_spec(Config)]).

--- a/src/erlcloud_ddb_streams.erl
+++ b/src/erlcloud_ddb_streams.erl
@@ -902,7 +902,7 @@ headers(Config, Operation, Body) ->
             _ ->
                 "us-east-1"
         end,
-    erlcloud_aws:sign_v4(Config, Headers, Body, Region, "dynamodb").
+    erlcloud_aws:sign_v4_headers(Config, Headers, Body, Region, "dynamodb").
 
 uri(#aws_config{ddb_streams_scheme = Scheme, ddb_streams_host = Host} = Config) ->
     lists:flatten([Scheme, Host, port_spec(Config)]).

--- a/src/erlcloud_kinesis_impl.erl
+++ b/src/erlcloud_kinesis_impl.erl
@@ -156,14 +156,7 @@ client_error(Status, StatusLine, Body) ->
 headers(Config, Operation, Body) ->
     Headers = [{"host", Config#aws_config.kinesis_host},
                {"x-amz-target", Operation}],
-    Region =
-        case string:tokens(Config#aws_config.kinesis_host, ".") of
-            [_, Value, _, _] ->
-                Value;
-            _ ->
-                "us-east-1"
-        end,
-    erlcloud_aws:sign_v4(Config, Headers, Body, Region, "kinesis").
+    erlcloud_aws:sign_v4_headers(Config, Headers, Body, erlcloud_aws:aws_region_from_host(Config#aws_config.kinesis_host), "kinesis").
 
 url(#aws_config{kinesis_scheme = Scheme, kinesis_host = Host} = Config) ->
     lists:flatten([Scheme, Host, port_spec(Config)]).

--- a/test/erlcloud_aws_tests.erl
+++ b/test/erlcloud_aws_tests.erl
@@ -7,7 +7,8 @@ request_test_() ->
      fun stop/1,
      [fun request_default_test/1,
       fun request_prot_host_port_str_test/1,
-      fun request_prot_host_port_int_test/1]}.
+      fun request_prot_host_port_int_test/1,
+      fun get_service_status_test/1]}.
 
 start() ->
     meck:new(erlcloud_httpc),
@@ -31,6 +32,65 @@ request_prot_host_port_int_test(_) ->
     ok = erlcloud_aws:aws_request(get, "http", "host1", 9999, "/path1", [], "id", "key"),
     Url = get_url_from_history(meck:history(erlcloud_httpc)),
     test_url(http, "host1", 9999, "/path1", Url).
+
+get_service_status_test(_) ->
+    StatusJsonS3 = jsx:encode(
+        [{<<"archive">>,
+            [[{<<"service_name">>,
+               <<"Amazon Simple Storage Service (US Standard)">>},
+              {<<"summary">>,
+               <<"[RESOLVED] Elevated errors for bucket operations in US-STANDARD ">>},
+              {<<"date">>,<<"1408497982">>},
+              {<<"status">>,1},
+              {<<"details">>,<<>>},
+              {<<"description">>,
+               <<"<div><span class=\"yellowfg\"> 6:46 PM PDT</span>&nbsp;We are investigatin">>},
+              {<<"service">>,<<"s3-us-standard">>}]
+            ]},
+         {<<"current">>,
+            [[{<<"service_name">>,
+               <<"Amazon Simple Storage Service (US Standard)">>},
+              {<<"summary">>,
+               <<"[RESOLVED] Elevated errors for bucket operations in US-STANDARD ">>},
+              {<<"date">>,<<"1408497982">>},
+              {<<"status">>,0},
+              {<<"details">>,<<>>},
+              {<<"description">>,
+               <<"<div><span class=\"yellowfg\"> 6:46 PM PDT</span>&nbsp;We are investigatin">>},
+              {<<"service">>,<<"s3-eu-central-1">>}]
+            ]}
+        ]
+    ),
+    OKStatusJson = jsx:encode(
+        [{<<"archive">>,
+            [[{<<"service_name">>,
+               <<"Amazon Simple Storage Service (US Standard)">>},
+              {<<"summary">>,
+               <<"[RESOLVED] Elevated errors for bucket operations in US-STANDARD ">>},
+              {<<"date">>,<<"1408497982">>},
+              {<<"status">>,1},
+              {<<"details">>,<<>>},
+              {<<"description">>,
+               <<"<div><span class=\"yellowfg\"> 6:46 PM PDT</span>&nbsp;We are investigatin">>},
+              {<<"service">>,<<"s3-us-standard">>}]
+            ]},
+         {<<"current">>,[]}
+        ]
+    ),
+
+    meck:expect(erlcloud_httpc, request, fun(_,_,_,_,_,_) -> {ok, {{200, "OK"}, [], StatusJsonS3}} end),
+    [S3Status] = erlcloud_aws:get_service_status("s3"),
+    meck:expect(erlcloud_httpc, request, fun(_,_,_,_,_,_) -> {ok, {{200, "OK"}, [], OKStatusJson}} end),
+    OKStatus = erlcloud_aws:get_service_status("sqs"),
+    meck:expect(erlcloud_httpc, request, fun(_,_,_,_,_,_) -> {ok, {{200, "OK"}, [], StatusJsonS3}} end),
+    OKStatusEC2 = erlcloud_aws:get_service_status("ec2"),
+    
+    ?debugFmt("OKStatusEC2 = ~p~n", [OKStatusEC2]),
+    [?_assertEqual(proplists:get_value(<<"status">>, S3Status), 0),
+     ?_assertEqual(proplists:get_value(<<"service">>, S3Status), <<"s3-eu-central-1">>),
+     ?_assertEqual(OKStatus, ok),
+     ?_assertEqual(OKStatusEC2, ok)
+     ].
 
 % ==================
 % Internal functions


### PR DESCRIPTION
this PR is part and preparation for https://github.com/gleber/erlcloud/pull/215

the purpose of this PR is mostly to commit common changes from `erlcloud_aws` module which will simplify further PRs to come

### What's changed? 
* adding x-amz-content-sha256 to header for signv4 (it will be needed for s3 related changes in further s3-related PRs)
* refactoring: move common code for retrieving region for host to one place
* https://github.com/alertlogic/erlcloud/pull/20 - added Reporting of AWS statuses using

All further PRs are expected to be as one PR per each AWS service.