### PR TITLE
Added get/list/describe api bindings in new erlcloud_cloudformation module

### DIFF
--- a/include/erlcloud_aws.hrl
+++ b/include/erlcloud_aws.hrl
@@ -34,6 +34,7 @@
           cloudtrail_scheme="https://"::string(),
           cloudtrail_host="cloudtrail.amazonaws.com"::string(),
           cloudtrail_port=80::non_neg_integer(),
+          cloudformation_host="cloudformation.us-east-1.amazonaws.com"::string(),
           access_key_id::string()|undefined|false,
           secret_access_key::string()|undefined|false,
           security_token=undefined::string()|undefined,

--- a/src/erlcloud_cloudformation.erl
+++ b/src/erlcloud_cloudformation.erl
@@ -1,0 +1,654 @@
+-module (erlcloud_cloudformation).
+
+-include_lib("erlcloud/include/erlcloud.hrl").
+-include_lib("erlcloud/include/erlcloud_aws.hrl").
+
+-define(API_VERSION, "2010-05-15").
+
+-type access_key_id() :: string().
+-type secret_access_key() :: string().
+
+-type params() :: proplists:proplist().
+-type cloudformation_list() :: proplists:proplist().
+
+
+%% lhttpc possible error reasons for lhttpc:request()
+-type error_reason() :: connection_closed | connect_timeout | timeout.
+
+%% Library initialization
+-export([
+    configure/2,
+    new/2
+]).
+
+
+%% Cloud Formation API Functions
+-export ([
+          list_stacks_all/1,
+          list_stacks_all/2,
+          list_stacks/2,
+          list_stacks/1,
+          list_stack_resources_all/2,
+          list_stack_resources_all/3,
+          list_stack_resources/2,
+          list_stack_resources/1,
+          describe_stack_resources/2,
+          describe_stack_resources/3,
+          describe_stack_resource/3,
+          describe_stack_resource/4,
+          describe_stacks_all/1,
+          describe_stacks_all/2,
+          describe_stacks/2,
+          describe_stacks/1,
+          get_stack_policy/2,
+          get_stack_policy/3,
+          get_template/2,
+          get_template/1,
+          get_template_summary/2,
+          get_template_summary/3,
+          describe_account_limits_all/0,
+          describe_account_limits_all/1,
+          describe_account_limits/2,
+          describe_account_limits/1,
+          describe_stack_events_all/1,
+          describe_stack_events_all/2,
+          describe_stack_events/2,
+          describe_stack_events/1]).
+
+
+%%==============================================================================
+%% Library initialization
+%%==============================================================================
+
+-spec configure(access_key_id(), secret_access_key()) -> ok.
+configure(AccessKeyID, SecretAccessKey) ->
+    put(aws_config, new(AccessKeyID, SecretAccessKey)),
+    ok.
+
+
+-spec new(access_key_id(), secret_access_key()) -> #aws_config{}.
+new(AccessKeyID, SecretAccessKey) ->
+    #aws_config{
+        access_key_id = AccessKeyID,
+        secret_access_key = SecretAccessKey
+    }.
+
+%%==============================================================================
+%% Cloud Formation API Functions
+%%==============================================================================
+-spec list_stacks_all(params()) -> {ok, cloudformation_list()}.
+list_stacks_all(Params) ->
+    list_stacks_all(Params, default_config()).
+
+-spec list_stacks_all(params(), aws_config()) -> {ok, cloudformation_list()}.
+list_stacks_all(Params, Config = #aws_config{}) ->
+    list_all(fun list_stacks/2, Params, Config, []).
+
+-spec list_stacks(params()) -> {ok, cloudformation_list()}
+| {error, error_reason()}.
+list_stacks(Params) ->
+    list_stacks(Params, default_config()).
+
+-spec list_stacks(params(), aws_config()) -> {ok, cloudformation_list()}
+    | {error, error_reason()}.
+list_stacks(Params, Config = #aws_config{}) ->
+
+     ExtraParams= lists:map(fun(T) ->
+            case T of
+                {stack_status_filter, N, Filter} ->
+                    {"StackStatusFilter.member." ++ integer_to_list(N), Filter};
+
+                _ -> convert_param(T)
+            end
+        end, Params),
+
+    case cloudformation_request(Config, "ListStacks", ExtraParams) of
+        {ok, XmlNode} ->
+            NextToken = erlcloud_xml:get_text(
+                    "/ListStacksResponse/ListStacksResult/NextToken",
+                    XmlNode,
+                    undefined),
+
+            StackSummaries = extract_stack_summaries(xmerl_xpath:string(
+                        "/ListStacksResponse/ListStacksResult",
+                        XmlNode)),
+            {ok, StackSummaries, NextToken};
+        {error, Error} ->
+            {error, Error}
+    end.
+
+-spec list_stack_resources_all(params(), string()) ->
+    {ok, cloudformation_list()} | {error, error_reason()}.
+list_stack_resources_all(Params, StackName) ->
+    list_stack_resources_all(Params, StackName, default_config()).
+
+-spec list_stack_resources_all(params(), string(), aws_config()) ->
+    {ok, cloudformation_list()} | {error, error_reason()}.
+list_stack_resources_all(Params, StackName, Config = #aws_config{}) ->
+
+    FullParams = [{"StackName", StackName}
+        | lists:map(
+            fun(T) ->
+                convert_param(T)
+            end, Params)],
+
+    list_all(fun list_stack_resources/2, FullParams, Config, []).
+
+-spec list_stack_resources(params()) ->
+    {ok, cloudformation_list()} | {error, error_reason()}.
+list_stack_resources(Params) ->
+    list_stack_resources(Params, default_config()).
+
+-spec list_stack_resources(params(), aws_config()) ->
+    {ok, cloudformation_list()} | {error, error_reason()}.
+list_stack_resources(Params, Config = #aws_config{}) ->
+
+    case cloudformation_request(Config, "ListStackResources", Params) of
+        {ok, XmlNode} ->
+            NextToken = erlcloud_xml:get_text(
+                "/ListStackResourcesResponse/"
+                "ListStackResourcesResult/NextToken",
+                XmlNode,
+                undefined),
+
+            StackResources = extract_list_stack_resources(xmerl_xpath:string(
+                "/ListStackResourcesResponse/ListStackResourcesResult",
+                XmlNode)),
+
+            {ok, StackResources, NextToken};
+        {error, Error} ->
+            {error, Error}
+    end.
+
+-spec describe_stack_resources(params(), string()) ->
+    {ok, cloudformation_list()} | {error, error_reason()}.
+describe_stack_resources(Params, StackName) ->
+    describe_stack_resources(Params, StackName, default_config()).
+
+-spec describe_stack_resources(params(), string(), aws_config()) ->
+    {ok, cloudformation_list()} | {error, error_reason()}.
+describe_stack_resources(Params, StackName, Config = #aws_config{}) ->
+
+    FullParams = [{"StackName", StackName}
+        | lists:map(
+            fun(T) ->
+                convert_param(T)
+            end, Params)],
+
+    case cloudformation_request(Config, "DescribeStackResources", FullParams) of
+        {ok, XmlNode} ->
+            extract_stack_resources_members(xmerl_xpath:string(
+                "/DescribeStackResourcesResponse",
+                XmlNode));
+
+        {error, Error} ->
+            {error, Error}
+    end.
+
+-spec describe_stack_resource(params(), string(), string()) ->
+    {ok, cloudformation_list()} | {error, error_reason()}.
+describe_stack_resource(Params, StackName, LogicalResourceId) ->
+    describe_stack_resource(Params, StackName, LogicalResourceId,
+        default_config()).
+
+-spec describe_stack_resource(params(), string(), string(), aws_config()) ->
+    {ok, cloudformation_list()} | {error, error_reason()}.
+describe_stack_resource(Params, StackName, LogicalResourceId,
+    Config = #aws_config{}) ->
+
+    FullParams = [{"StackName", StackName},
+        {"LogicalResourceId", LogicalResourceId}
+            | lists:map(
+                fun(T) ->
+                    convert_param(T)
+                end,Params)],
+
+    case cloudformation_request(Config, "DescribeStackResource", FullParams) of
+        {ok, XmlNode} ->
+            extract_stack_details(xmerl_xpath:string(
+                "/DescribeStackResourceResponse",
+                XmlNode));
+
+        {error, Error} ->
+            {error, Error}
+    end.
+
+-spec describe_stacks_all(params()) ->
+    {ok, cloudformation_list()} | {error, error_reason()}.
+describe_stacks_all(Params) ->
+    describe_stacks_all(Params, default_config()).
+
+-spec describe_stacks_all(params(), aws_config()) ->
+    {ok, cloudformation_list()} | {error, error_reason()}.
+describe_stacks_all(Params, Config = #aws_config{}) ->
+
+    RequestParams = lists:map(fun(T) -> convert_param(T) end, Params),
+
+    list_all(fun describe_stacks/2, RequestParams, Config, []).
+
+-spec describe_stacks(params()) ->
+    {ok, cloudformation_list()} | {error, error_reason()}.
+describe_stacks(Params) ->
+    describe_stacks(Params, default_config()).
+
+-spec describe_stacks(params(), aws_config()) ->
+    {ok, cloudformation_list()} | {error, error_reason()}.
+describe_stacks(Params, Config = #aws_config{}) ->
+
+    case cloudformation_request(Config, "DescribeStacks", Params) of
+        {ok, XmlNode} ->
+            NextToken = erlcloud_xml:get_text(
+                "/DescribeStacksResponse/DescribeStacksResult/NextToken",
+                XmlNode,
+                undefined),
+
+            DescribedStacks = extract_described_stacks_result(
+                xmerl_xpath:string(
+                    "/DescribeStacksResponse",
+                    XmlNode)
+            ),
+
+            {ok, DescribedStacks, NextToken};
+        {error, Error} ->
+            {error, Error}
+    end.
+
+-spec get_stack_policy(params(), string()) ->
+    {ok, cloudformation_list()} | {error, error_reason()}.
+get_stack_policy(Params, StackName) ->
+    get_stack_policy(Params, StackName, default_config()).
+
+-spec get_stack_policy(params(), string(), aws_config()) ->
+    {ok, cloudformation_list()} | {error, error_reason()}.
+get_stack_policy(Params, StackName, Config = #aws_config{}) ->
+
+    FullParams = [{"StackName", StackName}
+        | lists:map(
+            fun(T) ->
+                convert_param(T)
+            end, Params)],
+
+    case cloudformation_request(Config, "GetStackPolicy", FullParams) of
+        {ok, XmlNode} ->
+            extract_stack_policy_body(xmerl_xpath:string(
+                "/GetStackPolicyResponse",
+                XmlNode));
+
+        {error, Error} ->
+            {error, Error}
+    end.
+
+-spec describe_stack_events_all(params()) ->
+    {ok, cloudformation_list()} | {error, error_reason()}.
+describe_stack_events_all(Params) ->
+    describe_stack_events_all(Params, default_config()).
+
+-spec describe_stack_events_all(params(), aws_config()) ->
+    {ok, cloudformation_list()} | {error, error_reason()}.
+describe_stack_events_all(Params, Config = #aws_config{}) ->
+
+    RequestParams = lists:map(
+        fun(T) ->
+            convert_param(T)
+        end, Params),
+
+    list_all(fun describe_stack_events/2, RequestParams, Config, []).
+
+-spec describe_stack_events(params()) ->
+    {ok, cloudformation_list()} | {error, error_reason()}.
+describe_stack_events(Params) ->
+    describe_stack_events(Params, default_config()).
+
+-spec describe_stack_events(params(), aws_config()) ->
+    {ok, cloudformation_list()} | {error, error_reason()}.
+describe_stack_events(Params, Config = #aws_config{}) ->
+
+    case cloudformation_request(Config, "DescribeStackEvents", Params) of
+        {ok, XmlNode} ->
+            NextToken = erlcloud_xml:get_text(
+                "/DescribeStackEventsResponse/DescribeStackEventsResult"
+                "/NextToken",
+                XmlNode,
+                undefined),
+
+            StackEvents = extract_described_stack_events_result(
+                xmerl_xpath:string("/DescribeStackEventsResponse", XmlNode)),
+            {ok, StackEvents, NextToken};
+        {error, Error} ->
+            {error, Error}
+    end.
+
+-spec get_template(string()) ->
+    {ok, cloudformation_list()} | {error, error_reason()}.
+get_template(StackName) ->
+    get_template(StackName, default_config()).
+
+-spec get_template(string(), aws_config()) ->
+    {ok, cloudformation_list()} | {error, error_reason()}.
+get_template(StackName, Config = #aws_config{}) ->
+
+    case cloudformation_request(Config, "GetTemplate",
+            [{"StackName", StackName}]) of
+        {ok, XmlNode} ->
+            extract_template_response(XmlNode);
+        {error, Error} ->
+            {error, Error}
+    end.
+
+-spec get_template_summary(params(), string()) ->
+    {ok, cloudformation_list()} | {error, error_reason()}.
+get_template_summary(Params, StackName) ->
+    get_template_summary(Params, StackName, default_config).
+
+-spec get_template_summary(params(), string(), aws_config()) ->
+    {ok, cloudformation_list()} | {error, error_reason()}.
+get_template_summary(Params, StackName, Config = #aws_config{}) ->
+
+    FullParams = [{"StackName", StackName}
+        | lists:map(
+            fun(T) ->
+                convert_param(T)
+            end, Params)],
+
+    case cloudformation_request(Config, "GetTemplateSummary", FullParams) of
+        {ok, XmlNodes} ->
+            extract_template_summary_response(XmlNodes);
+        {error, Error} ->
+            {error, Error}
+    end.
+
+-spec describe_account_limits_all() ->
+    {ok, cloudformation_list()} | {error, error_reason()}.
+describe_account_limits_all() ->
+    describe_account_limits_all(default_config).
+
+-spec describe_account_limits_all(aws_config()) ->
+    {ok, cloudformation_list()} | {error, error_reason()}.
+describe_account_limits_all(Config = #aws_config{}) ->
+    list_all(fun describe_account_limits/2, [], Config, []).
+
+-spec describe_account_limits(params) ->
+    {ok, cloudformation_list()} | {error, error_reason()}.
+describe_account_limits(Params) ->
+    describe_account_limits(Params, default_config()).
+
+-spec describe_account_limits(params, aws_config()) ->
+    {ok, cloudformation_list()} | {error, error_reason()}.
+describe_account_limits(Params, Config = #aws_config{}) ->
+
+    RequestParams = lists:map(fun(T) -> convert_param(T) end, Params),
+
+    case cloudformation_request(Config, "DescribeAccountLimits",
+            RequestParams) of
+        {ok, XmlNodes} ->
+            NextToken = erlcloud_xml:get_text(
+                "/DescribeAccountLimitsResponse/DescribeAccountLimitsResult/"
+                "NextToken",
+                XmlNodes,
+                undefined),
+
+            AccountLimits = extract_accout_limits_response(xmerl_xpath:string(
+                "/DescribeAccountLimitsResponse",
+                XmlNodes)),
+
+            {ok, AccountLimits, NextToken};
+        {error, Error} ->
+            {error, Error}
+    end.
+
+%%==============================================================================
+%% Internal functions
+%%==============================================================================
+
+convert_param({Key, Value}) ->
+    case Key of
+        stack_name -> {"StackName", Value};
+        stack_id -> {"StackName", Value};
+        logical_resource_id -> {"LogicalResourceId", Value};
+        next_token -> {"NextToken", Value}
+    end.
+
+default_config() ->
+    erlcloud_aws:default_config().
+
+cloudformation_request(Config = #aws_config{}, Action, ExtraParams) ->
+
+    QParams = [
+        {"Action", Action},
+        {"Version", ?API_VERSION}
+        | ExtraParams],
+
+    erlcloud_aws:aws_request_xml4(post, Config#aws_config.cloudformation_host,
+        "/", QParams, "cloudformation", Config).
+
+list_all(Fun, Params, Config, Acc) ->
+    case Fun(Params, Config) of
+        {ok, Data, NextToken} ->
+            case NextToken of
+                undefined ->
+                    lists:foldl(fun erlang:'++'/2, [], [Data | Acc]);
+                _ ->
+                    list_all(Fun, [{next_token, NextToken} | Params],
+                        Config, [Data | Acc])
+            end;
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+extract_stack_summaries(XmlNodes) ->
+    lists:map(fun(T) -> erlcloud_xml:decode([{summaries, "StackSummaries",
+        {map, fun extract_stacks/1}}], T) end, XmlNodes).
+
+extract_stacks(XmlNode) ->
+    erlcloud_xml:decode([
+            {member, "member", {map, fun extract_stack/1}}
+        ], XmlNode).
+
+extract_stack(XmlNode) ->
+    erlcloud_xml:decode([
+        {stack_id, "StackId", optional_text},
+        {stack_status, "StackStatus", optional_text},
+        {stack_name, "StackName", optional_text},
+        {creation_time, "CreationTime", optional_text},
+        {template_description, "TemplateDescription", optional_text},
+        {resource_types, "ResourceTypes", list}], XmlNode).
+
+extract_list_stack_resources(XmlNodes) ->
+    lists:map(fun(T) -> erlcloud_xml:decode([
+        {summaries, "StackResourceSummaries",
+            {map, fun extract_list_resources/1}}
+        ], T) end, XmlNodes).
+
+extract_list_resources(XmlNode) ->
+    erlcloud_xml:decode([
+        {member, "member", {map, fun extract_list_resource/1}}
+        ], XmlNode).
+
+extract_list_resource(XmlNode) ->
+    erlcloud_xml:decode([
+        {resource_status, "ResourceStatus", optional_text},
+        {logical_resource_id, "LogicalResourceId", optional_text},
+        {last_updated_timestamp, "LastUpdatedTimestamp", optional_text},
+        {physical_resource_id, "PhysicalResourceId", optional_text},
+        {resource_type, "ResourceType", optional_text}
+        ], XmlNode).
+
+extract_stack_resources_members(XmlNodes) ->
+    lists:map(fun(T) -> erlcloud_xml:decode([
+        {resources, "DescribeStackResourcesResult/StackResources",
+            {map, fun extract_member_resources/1}},
+
+        {response_meta, "ResponseMetadata",
+            {map, fun extract_template_meta_body/1}}
+
+        ], T) end, XmlNodes).
+
+extract_member_resources(XmlNode) ->
+    erlcloud_xml:decode([{member, "member",
+        {map, fun extract_resource/1}}], XmlNode).
+
+extract_resource(XmlNode) ->
+    erlcloud_xml:decode([
+        {stack_id, "StackId", optional_text},
+        {stack_name, "StackName", optional_text},
+        {logical_resource_id, "LogicalResourceId", optional_text},
+        {physical_resource_id, "PhysicalResourceId", optional_text},
+        {resource_type, "ResourceType", optional_text},
+        {timestamp, "Timestamp", optional_text},
+        {resource_status, "ResourceStatus", optional_text}
+        ], XmlNode).
+
+extract_stack_details(XmlNodes) ->
+    lists:map(fun(T) -> erlcloud_xml:decode(
+        [{resources, "DescribeStackResourceResult/StackResourceDetail",
+            {map, fun extract_resource/1}},
+         {response_meta, "ResponseMetadata",
+            {map, fun extract_template_meta_body/1}}
+            ], T) end, XmlNodes).
+
+extract_described_stacks_result(XmlNodes) ->
+    lists:map(fun(T) -> erlcloud_xml:decode([
+        {stacks, "DescribeStacksResult/Stacks",
+            {map, fun extract_described_stacks/1}},
+        {response_meta, "ResponseMetadata",
+            {map, fun extract_template_meta_body/1}}
+    ], T) end, XmlNodes).
+
+extract_described_stacks(XmlNode) ->
+    erlcloud_xml:decode([{member, "member",
+        {map, fun extract_described_stack/1}}], XmlNode).
+
+extract_described_stack(XmlNode) ->
+    erlcloud_xml:decode([
+            {stack_name, "StackName", optional_text},
+            {stack_id, "StackId", optional_text},
+            {creation_time, "CreationTime", optional_text},
+            {stack_status, "StackStatus", optional_text},
+            {disable_rollback, "DisableRollback", optional_text},
+            {outputs, "Outputs", {map, fun extract_resource_outputs/1}}
+        ], XmlNode).
+
+extract_resource_outputs(XmlNode) ->
+    erlcloud_xml:decode([
+            {member, "member", {map, fun extract_resource_output/1}}
+        ], XmlNode).
+
+extract_resource_output(XmlNode) ->
+    erlcloud_xml:decode([
+            {output_key, "OutputKey", optional_text},
+            {output_value, "OutputValue", optional_text}
+        ], XmlNode).
+
+extract_stack_policy_body(XmlNodes) ->
+    lists:map(fun(T) -> erlcloud_xml:decode([
+                {stack_policy_body, "GetStackPolicyResult/StackPolicyBody/",
+                    optional_text},
+
+                {response_meta, "ResponseMetadata",
+                    {map, fun extract_template_meta_body/1}}
+
+            ], T) end, XmlNodes).
+
+extract_described_stack_events_result(XmlNodes) ->
+    lists:map(fun(T) -> erlcloud_xml:decode([
+                {stack_events, "DescribeStackEventsResult/StackEvents",
+                    {map, fun extract_stack_event_member/1}},
+
+                {response_meta, "ResponseMetadata",
+                    {map, fun extract_template_meta_body/1}}
+
+            ], T) end, XmlNodes).
+
+extract_stack_event_member(XmlNode) ->
+    erlcloud_xml:decode([
+            {member, "member", {map, fun extract_stack_event/1}}
+    ], XmlNode).
+
+extract_stack_event(XmlNode) ->
+    erlcloud_xml:decode([
+            {event_id, "EventId", optional_text},
+            {stack_id, "StackId", optional_text},
+            {stack_name, "StackName", optional_text},
+            {logical_resource_id, "LogicalResourceId", optional_text},
+            {physical_resource_id, "PhysicalResourceId", optional_text},
+            {resource_type, "ResourceType", optional_text},
+            {timestamp, "TimeStamp", optional_text},
+            {resource_status, "ResourceStatus", optional_text},
+            {resource_properties, "ResourceProperties", optional_text}
+    ], XmlNode).
+
+extract_template_response(XmlNodes) ->
+    erlcloud_xml:decode([
+                {template_result, "GetTemplateResult",
+                    {map, fun extract_template_result/1}},
+                {response_meta, "ResponseMetadata",
+                    {map, fun extract_template_meta_body/1}}
+            ], XmlNodes).
+
+extract_template_meta_body(XmlNode) ->
+    erlcloud_xml:decode([{request_id, "RequestId", optional_text}], XmlNode).
+
+extract_template_result(XmlNode) ->
+    erlcloud_xml:decode([{template_body, "TemplateBody", optional_text}],
+        XmlNode).
+
+extract_template_summary_response(XmlNodes) ->
+    erlcloud_xml:decode([
+                {template_summary_result, "GetTemplateSummaryResult",
+                    {map, fun extract_template_summary_result/1}},
+                {response_meta, "ResponseMetadata",
+                    {map, fun extract_template_meta_body/1}}
+        ], XmlNodes).
+
+extract_template_summary_result(XmlNode) ->
+    erlcloud_xml:decode([
+                {description, "Description", optional_text},
+                {parameters, "Parameters",
+                    {map, fun extract_template_parameters/1}},
+                {metadata, "Metadata", optional_text},
+                {version, "Version", optional_text}
+        ], XmlNode).
+
+extract_template_parameters(XmlNode) ->
+    erlcloud_xml:decode([
+                {member, "member",
+                    {map, fun extract_template_parameter/1}}
+        ], XmlNode).
+
+extract_template_parameter(XmlNode) ->
+    erlcloud_xml:decode([
+                {no_echo, "NoEcho", optional_text},
+                {parameter_key, "ParameterKey", optional_text},
+                {description, "Description", optional_text},
+                {parameter_type, "ParameterType", optional_text}
+        ], XmlNode).
+
+extract_accout_limits_response(XmlNodes) ->
+    lists:map(fun(T) -> erlcloud_xml:decode([
+            {describe_account_limits_result, "DescribeAccountLimitsResult",
+                {map, fun extract_account_limits_result/1}},
+            {response_meta, "ResponseMetadata",
+                {map, fun extract_template_meta_body/1}}
+        ], T) end, XmlNodes).
+
+extract_account_limits_result(XmlNode) ->
+    erlcloud_xml:decode([
+            {account_limits, "AccountLimits",
+                {map, fun extract_account_limits/1}}
+        ], XmlNode).
+
+extract_account_limits(XmlNode) ->
+    erlcloud_xml:decode([
+            {member, "member",
+                {map, fun extract_account_limit/1}}
+        ], XmlNode).
+
+extract_account_limit(XmlNode) ->
+    erlcloud_xml:decode([
+            {name, "Name", optional_text},
+            {value, "Value", optional_text}
+        ], XmlNode).
+
+
+
+

--- a/test/erlcloud_cloudformation_tests.erl
+++ b/test/erlcloud_cloudformation_tests.erl
@@ -1,0 +1,583 @@
+%% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
+-module(erlcloud_cloudformation_tests).
+
+
+-include_lib("eunit/include/eunit.hrl").
+-include("erlcloud.hrl").
+-include("erlcloud_aws.hrl").
+
+-define(_cloudformation_test(T), {?LINE, T}).
+
+-define(_f(F), fun() -> F end).
+
+%%==============================================================================
+%% Test entry points
+%%==============================================================================
+
+describe_cloudformation_test_() ->
+    {foreach, fun start/0, fun stop/1, [
+        fun list_stacks_all_output_tests/1,
+        fun list_stack_resources_output_tests/1,
+        fun get_template_summary_output_tests/1,
+        fun get_template_output_tests/1,
+        fun get_stack_policy_output_tests/1,
+        fun describe_stacks_output_tests/1,
+        fun describe_stack_resources_output_tests/1,
+        fun describe_stack_resource_output_tests/1,
+        fun describe_stack_events_output_tests/1,
+        fun describe_account_limits_output_tests/1,
+        fun list_stacks_all_input_tests/1,
+        fun list_stack_resources_input_tests/1,
+        fun get_template_summary_input_tests/1,
+        fun get_template_input_tests/1,
+        fun get_stack_policy_input_tests/1,
+        fun describe_stacks_input_tests/1,
+        fun describe_stack_resources_input_tests/1,
+        fun describe_stack_resource_input_tests/1,
+        fun describe_stack_events_input_tests/1,
+        fun describe_account_limits_input_tests/1
+    ]}.
+
+start() ->
+    meck:new(erlcloud_aws),
+    ok.
+
+stop(_) ->
+    meck:unload(erlcloud_aws).
+
+%%==============================================================================
+%% Output Test helpers
+%%==============================================================================
+
+output_test(Fun, {Line, {Description, Response, Result}}) ->
+    {Description, {Line, fun() ->
+                        meck:expect(erlcloud_aws, aws_request_xml4, 6,
+                               {ok, element(1, xmerl_scan:string(
+                                    binary_to_list(Response)))}
+                            ),
+                        Actual = Fun(),
+                        ?assertEqual(Result, Actual)
+                    end}}.
+
+
+%%==============================================================================
+%% Input Test helpers
+%%==============================================================================
+
+validate_param(_Param = {Key, _Value}, Params) ->
+    true = proplists:is_defined(Key, Params).
+
+validate_params(Params, Expected) ->
+    [validate_param(X, Params)
+        || X <- [{"Action", ""}, {"Version", ""} | Expected]
+
+    ].
+input_expect(Response, Params) ->
+
+    fun(post, "cloudformation.us-east-1.amazonaws.com", "/", QParams,
+            "cloudformation", _) ->
+        validate_params(QParams, Params),
+        Response
+    end.
+
+input_test(Response, {Line, {Description, Fun, Params}})
+    when is_list(Description) ->
+
+    InputFunction = input_expect(Response, Params),
+
+    meck:expect(erlcloud_aws, aws_request_xml4, InputFunction),
+
+    {Description, {Line, fun() ->
+            Fun()
+        end}}.
+
+
+%%==============================================================================
+%% Input Tests
+%%==============================================================================
+
+list_stacks_all_input_tests(_) ->
+    Response = {ok, element(1, xmerl_scan:string(
+            binary_to_list(<<"<ListStacksResponse>null</ListStacksResponse>">>)
+        ))},
+
+    ExpectedParams = [],
+
+    input_test(Response, ?_cloudformation_test({"Test list all stacks input",
+        ?_f(erlcloud_cloudformation:list_stacks_all([], #aws_config{})),
+        ExpectedParams})).
+
+list_stack_resources_input_tests(_) ->
+    Response = {ok, element(1, xmerl_scan:string(
+        binary_to_list(<<"<ListStackResourcesResponse>null"
+            "</ListStackResourcesResponse>">>)
+    ))},
+
+    ExpectedParams = [{"StackName", ""}],
+
+    input_test(Response, ?_cloudformation_test({"Test list all stack resources",
+        ?_f(erlcloud_cloudformation:list_stack_resources_all([],
+            "Stack Name", #aws_config{})), ExpectedParams})).
+
+get_template_summary_input_tests(_) ->
+    Response = {ok, element(1, xmerl_scan:string(
+        binary_to_list(<<"<GetTemplateSummaryResponse>null"
+            "</GetTemplateSummaryResponse>">>)
+    ))},
+
+    ExpectedParams = [{"StackName", ""}],
+
+    input_test(Response, ?_cloudformation_test({"Test get template summary",
+        ?_f(erlcloud_cloudformation:get_template_summary([],
+        "Stack Name", #aws_config{})), ExpectedParams})).
+
+get_template_input_tests(_) ->
+    Response = {ok, element(1, xmerl_scan:string(
+        binary_to_list(<<"<GetTemplateResponse>null</GetTemplateResponse>">>)
+    ))},
+
+    ExpectedParams = [{"StackName", ""}],
+
+    input_test(Response, ?_cloudformation_test({"Test get template",
+        ?_f(erlcloud_cloudformation:get_template("Stack Name", #aws_config{})),
+        ExpectedParams})).
+
+get_stack_policy_input_tests(_) ->
+    Response = {ok, element(1, xmerl_scan:string(
+        binary_to_list(<<"<GetStackPolicyResult>null</GetStackPolicyResult>">>)
+    ))},
+
+    ExpectedParams = [{"StackName", ""}],
+
+    input_test(Response, ?_cloudformation_test({"Test get stack policy",
+        ?_f(erlcloud_cloudformation:get_stack_policy([],
+            "Stack Name", #aws_config{})), ExpectedParams})).
+
+describe_stacks_input_tests(_) ->
+    Response = {ok, element(1, xmerl_scan:string(
+        binary_to_list(<<"<DescribeStacksResponse>null"
+            "</DescribeStacksResponse>">>)
+    ))},
+
+    ExpectedParams = [],
+
+    input_test(Response, ?_cloudformation_test({"Test describe stacks all",
+        ?_f(erlcloud_cloudformation:describe_stacks_all(
+            ExpectedParams,#aws_config{})), ExpectedParams})).
+
+describe_stack_resources_input_tests(_) ->
+    Response = {ok, element(1, xmerl_scan:string(
+        binary_to_list(<<"<DescribeStackResourcesResponse>null"
+            "</DescribeStackResourcesResponse>">>)
+    ))},
+
+    ExpectedParams = [{"StackName", ""}],
+
+    input_test(Response, ?_cloudformation_test(
+        {"Test describe stack resources all",
+        ?_f(erlcloud_cloudformation:describe_stack_resources([],
+            "Stack Name", #aws_config{})), ExpectedParams})).
+
+describe_stack_resource_input_tests(_) ->
+    Response = {ok, element(1, xmerl_scan:string(
+        binary_to_list(<<"<DescribeStackResourceResponse>null"
+            "</DescribeStackResourceResponse>">>)
+    ))},
+
+    ExpectedParams = [{"StackName", ""}, {"LogicalResourceId", ""}],
+
+    input_test(Response, ?_cloudformation_test(
+        {"Test describe stack resource",
+        ?_f(erlcloud_cloudformation:describe_stack_resource(
+            [], "Stack Name", "Logical Resource Id",
+            #aws_config{})), ExpectedParams})).
+
+describe_stack_events_input_tests(_) ->
+    Response = {ok, element(1, xmerl_scan:string(
+        binary_to_list(<<"<DescribeStackEventsResponse>null"
+            "</DescribeStackEventsResponse>">>)
+    ))},
+
+    ExpectedParams = [{"StackName", ""}],
+
+    input_test(Response, ?_cloudformation_test(
+        {"Test describe all stack events",
+        ?_f(erlcloud_cloudformation:describe_stack_events_all(
+            [{stack_name, ""}], #aws_config{})), ExpectedParams})).
+
+describe_account_limits_input_tests(_) ->
+    Response = {ok, element(1, xmerl_scan:string(
+        binary_to_list(<<"<DescribeAccountLimitsResponse>null"
+            "</DescribeAccountLimitsResponse>">>)
+    ))},
+
+    ExpectedParams = [],
+
+    input_test(Response, ?_cloudformation_test(
+            {"test describe all account limits",
+                ?_f(erlcloud_cloudformation:describe_account_limits_all(
+                    #aws_config{})),
+            ExpectedParams})).
+
+
+%%==============================================================================
+%% Output Tests
+%%==============================================================================
+
+
+list_stacks_all_output_tests(_) ->
+    Test = ?_cloudformation_test({"Test listing all stacks",
+                <<"<ListStacksResponse xmlns="
+                "\"http://cloudformation.amazonaws.com/doc/2010-05-15/\">
+                <NextToken>
+                null
+                </NextToken>
+                <ListStacksResult>
+                    <StackSummaries>
+                        <member>
+                            <StackId>Stack ID</StackId>
+                            <StackStatus>Status</StackStatus>
+                            <StackName>Stack Name</StackName>
+                            <CreationTime>2015-05-23T15:47:44Z</CreationTime>
+                            <TemplateDescription>Description"
+                            "</TemplateDescription>
+                            <ResourceTypes><member>Resource</member>"
+                            "</ResourceTypes>
+                        </member>
+                    </StackSummaries>
+                </ListStacksResult>
+            </ListStacksResponse>">>,
+            [
+                [{summaries, [[{member,
+                     [[{stack_id, "Stack ID"},
+                      {stack_status, "Status"},
+                      {stack_name, "Stack Name"},
+                      {creation_time, "2015-05-23T15:47:44Z"},
+                      {template_description, "Description"},
+                      {resource_types, ["Resource"]}
+                    ]]}
+                ]]}]
+            ]
+        }),
+
+    output_test(?_f(erlcloud_cloudformation:list_stacks_all(
+                [], Config = #aws_config{})), Test).
+
+
+list_stack_resources_output_tests(_) ->
+
+    Test = ?_cloudformation_test({"Test listing all stack resources",
+            <<"<ListStackResourcesResponse xmlns="
+            "\"http://cloudformation.amazonaws.com/doc/2010-05-15/\">
+                <ListStackResourcesResult>
+                    <StackResourceSummaries>
+                        <member>
+                            <ResourceStatus>Some Status</ResourceStatus>
+                            <LogicalResourceId>DBSecurityGroup"
+                            "</LogicalResourceId>
+                            <LastUpdatedTimestamp>2015-06-21T20:25:57Z"
+                            "</LastUpdatedTimestamp>
+                            <PhysicalResourceId>Some Resource ID"
+                            "</PhysicalResourceId>
+                            <ResourceType>Some Resource Type</ResourceType>
+                        </member>
+                    </StackResourceSummaries>
+                </ListStackResourcesResult>
+                <ResponseMetadata>
+                    <RequestId>Some Request ID</RequestId>
+                </ResponseMetadata>
+            </ListStackResourcesResponse>">>,
+
+            [
+                [{summaries, [[{member,
+                    [[{resource_status, "Some Status"},
+                      {logical_resource_id, "DBSecurityGroup"},
+                      {last_updated_timestamp, "2015-06-21T20:25:57Z"},
+                      {physical_resource_id, "Some Resource ID"},
+                      {resource_type, "Some Resource Type"}]]
+                }]]}]
+            ]
+        }),
+
+    output_test(?_f(erlcloud_cloudformation:list_stack_resources_all([],
+                "Stack Name", Config = #aws_config{})), Test).
+
+get_template_summary_output_tests(_) ->
+
+    Test = ?_cloudformation_test({"Test get template summary",
+            <<"<GetTemplateSummaryResponse xmlns="
+                "\"http://cloudformation.amazonaws.com/doc/2010-05-15/\">
+              <GetTemplateSummaryResult>
+                <Description>description</Description>
+                <Parameters>
+                  <member>
+                    <NoEcho>false</NoEcho>
+                    <ParameterKey>KeyName</ParameterKey>
+                    <Description>description</Description>
+                    <ParameterType>Type</ParameterType>
+                  </member>
+                </Parameters>
+                <Metadata>metadata</Metadata>
+                <Version>version</Version>
+              </GetTemplateSummaryResult>
+              <ResponseMetadata>
+                <RequestId>request ID</RequestId>
+              </ResponseMetadata>
+            </GetTemplateSummaryResponse>">>,
+
+            [
+                {template_summary_result, [[{description, "description"},
+                {parameters, [[
+                    {member, [[{no_echo, "false"},
+                               {parameter_key, "KeyName"},
+                               {description, "description"},
+                               {parameter_type, "Type"}]]}
+                ]]},
+                {metadata, "metadata"},
+                {version, "version"}]]},
+                {response_meta, [[{request_id, "request ID"}]]}
+            ]
+        }),
+
+    output_test(?_f(erlcloud_cloudformation:get_template_summary([],
+                "Stack Name", Config = #aws_config{}
+            )), Test).
+
+get_template_output_tests(_) ->
+
+    Test = ?_cloudformation_test({"Test get template",
+
+            <<"<GetTemplateResponse xmlns="
+            "\"http://cloudformation.amazonaws.com/doc/2010-05-15/\">
+                <GetTemplateResult>
+                  <TemplateBody>template body</TemplateBody>
+                </GetTemplateResult>
+                <ResponseMetadata>
+                  <RequestId>request ID</RequestId>
+                </ResponseMetadata>
+            </GetTemplateResponse>">>,
+            [
+                {template_result, [[{template_body, "template body"}]]},
+                {response_meta, [[{request_id, "request ID"}]]}
+            ]
+        }),
+
+    output_test(?_f(erlcloud_cloudformation:get_template(
+                "Some Stack Name", Config = #aws_config{}
+            )), Test).
+
+get_stack_policy_output_tests(_) ->
+
+    Test = ?_cloudformation_test({"Test get stack policy",
+            <<"<GetStackPolicyResponse xmlns="
+            "\"http://cloudformation.amazonaws.com/doc/2010-05-15/\">
+              <GetStackPolicyResult>
+                  <StackPolicyBody>Policy</StackPolicyBody>
+              </GetStackPolicyResult>
+              <ResponseMetadata>
+                <RequestId>request ID</RequestId>
+              </ResponseMetadata>
+            </GetStackPolicyResponse>">>,
+            [
+                [{stack_policy_body ,"Policy"},
+                 {response_meta, [[{request_id, "request ID"}]]}]
+            ]
+        }),
+
+    output_test(?_f(erlcloud_cloudformation:get_stack_policy([],
+                "Stack Name", Config = #aws_config{}
+            )), Test).
+
+describe_stacks_output_tests(_) ->
+
+    Test = ?_cloudformation_test({"Test describe all stacks",
+            <<"<DescribeStacksResponse xmlns="
+            "\"http://cloudformation.amazonaws.com/doc/2010-05-15/\">
+              <DescribeStacksResult>
+                <Stacks>
+                  <member>
+                    <StackName>My Stack</StackName>
+                    <StackId>Stack Id</StackId>
+                    <CreationTime>Not Today</CreationTime>
+                    <StackStatus>status</StackStatus>
+                    <DisableRollback>false</DisableRollback>
+                    <Outputs>
+                      <member>
+                        <OutputKey>Some Key</OutputKey>
+                        <OutputValue>Output</OutputValue>
+                      </member>
+                    </Outputs>
+                  </member>
+                </Stacks>
+              </DescribeStacksResult>
+              <ResponseMetadata>
+                <RequestId>request ID</RequestId>
+              </ResponseMetadata>
+            </DescribeStacksResponse>">>,
+
+            [[{stacks, [[
+                {member, [[{stack_name, "My Stack"},
+                           {stack_id, "Stack Id"},
+                           {creation_time, "Not Today"},
+                           {stack_status, "status"},
+                           {disable_rollback, "false"},
+                           {outputs, [[
+                                {member, [[
+                                    {output_key, "Some Key"},
+                                    {output_value, "Output"}
+                                ]]}
+                            ]]}
+                ]]}
+            ]]},{response_meta, [[{request_id, "request ID"}]]}]]
+        }),
+
+    output_test(?_f(erlcloud_cloudformation:describe_stacks_all(
+                [{stack_name, "Some Stack Name"}], Config = #aws_config{}
+            )), Test).
+
+describe_stack_resources_output_tests(_) ->
+
+    Test = ?_cloudformation_test({"Test describe stack resources",
+            <<"<DescribeStackResourcesResponse xmlns="
+            "\"http://cloudformation.amazonaws.com/doc/2010-05-15/\">
+              <DescribeStackResourcesResult>
+                <StackResources>
+                  <member>
+                    <StackId>Stack ID</StackId>
+                    <StackName>My Stack</StackName>
+                    <LogicalResourceId>MyDBInstance</LogicalResourceId>
+                    <PhysicalResourceId>Resource ID</PhysicalResourceId>
+                    <ResourceType>Resource Type</ResourceType>
+                    <Timestamp>Timestamp</Timestamp>
+                    <ResourceStatus>Status</ResourceStatus>
+                  </member>
+                </StackResources>
+              </DescribeStackResourcesResult>
+              <ResponseMetadata>
+                <RequestId>Request ID</RequestId>
+              </ResponseMetadata>
+            </DescribeStackResourcesResponse>">>,
+
+            [[{resources, [[{member, [[
+                {stack_id, "Stack ID"},
+                {stack_name, "My Stack"},
+                {logical_resource_id, "MyDBInstance"},
+                {physical_resource_id, "Resource ID"},
+                {resource_type, "Resource Type"},
+                {timestamp, "Timestamp"},
+                {resource_status, "Status"}]]}]]},
+            {response_meta, [[{request_id, "Request ID"}]]}]
+            ]
+        }),
+
+    output_test(?_f(erlcloud_cloudformation:describe_stack_resources([],
+                "Stack Name", Config = #aws_config{}
+            )), Test).
+
+describe_stack_resource_output_tests(_) ->
+
+    Test = ?_cloudformation_test({"Test describe stack resource",
+            <<"<DescribeStackResourceResponse xmlns="
+            "\"http://cloudformation.amazonaws.com/doc/2010-05-15/\">
+             <DescribeStackResourceResult>
+               <StackResourceDetail>
+                 <StackId>Stack ID</StackId>
+                 <StackName>My Stack</StackName>
+                 <LogicalResourceId>MyDBInstance</LogicalResourceId>
+                 <PhysicalResourceId>Resource ID</PhysicalResourceId>
+                 <ResourceType>Resource Type</ResourceType>
+                 <LastUpdatedTimestamp>Tiemstamp</LastUpdatedTimestamp>
+                 <ResourceStatus>Status</ResourceStatus>
+               </StackResourceDetail>
+             </DescribeStackResourceResult>
+             <ResponseMetadata>
+               <RequestId>Request ID</RequestId>
+             </ResponseMetadata>
+            </DescribeStackResourceResponse>">>,
+            [[{resources,
+                [[{stack_id, "Stack ID"},
+                  {stack_name, "My Stack"},
+                  {logical_resource_id, "MyDBInstance"},
+                  {physical_resource_id, "Resource ID"},
+                  {resource_type, "Resource Type"},
+                  {resource_status, "Status"}]]
+            },
+            {response_meta, [[{request_id, "Request ID"}]]}]]
+        }),
+
+    output_test(?_f(erlcloud_cloudformation:describe_stack_resource([],
+                "Stack Name", "Logical Id", Config = #aws_config{}
+            )), Test).
+
+describe_stack_events_output_tests(_) ->
+
+    Test = ?_cloudformation_test({"Test describe alls tack events",
+            <<"<DescribeStackEventsResponse xmlns="
+            "\"http://cloudformation.amazonaws.com/doc/2010-05-15/\">
+              <DescribeStackEventsResult>
+                <StackEvents>
+                  <member>
+                    <EventId>Event ID</EventId>
+                    <StackId>Stack ID</StackId>
+                    <StackName>My Stack</StackName>
+                    <LogicalResourceId>Resource ID</LogicalResourceId>
+                    <PhysicalResourceId>Resource ID</PhysicalResourceId>
+                    <ResourceType>Resource Type</ResourceType>
+                    <Timestamp>Timestamp</Timestamp>
+                    <ResourceStatus>Resource Status</ResourceStatus>
+                    <ResourceStatusReason>Resource Status Reason"
+                    "</ResourceStatusReason>
+                  </member>
+                </StackEvents>
+              </DescribeStackEventsResult>
+              <ResponseMetadata>
+                <RequestId>Request ID</RequestId>
+              </ResponseMetadata>
+            </DescribeStackEventsResponse>">>,
+
+            [[{stack_events, [[{
+                member, [[
+                {event_id, "Event ID"},
+                {stack_id, "Stack ID"},
+                {stack_name, "My Stack"},
+                {logical_resource_id, "Resource ID"},
+                {physical_resource_id, "Resource ID"},
+                {resource_type, "Resource Type"},
+                {resource_status, "Resource Status"}]]}]]},
+            {response_meta, [[{request_id, "Request ID"}]]}]]
+        }),
+
+    output_test(?_f(erlcloud_cloudformation:describe_stack_events_all(
+                [{stack_name, "Some Stack Name"}], Config = #aws_config{}
+            )), Test).
+
+describe_account_limits_output_tests(_) ->
+
+    Test = ?_cloudformation_test({"Test describe all account limits",
+            <<"<DescribeAccountLimitsResponse xmlns="
+            "\"http://cloudformation.amazonaws.com/doc/2010-05-15/\">
+              <DescribeAccountLimitsResult>
+                <AccountLimits>
+                  <member>
+                    <Name>Name</Name>
+                    <Value>Value</Value>
+                  </member>
+                </AccountLimits>
+              </DescribeAccountLimitsResult>
+              <ResponseMetadata>
+                <RequestId>Request ID</RequestId>
+              </ResponseMetadata>
+            </DescribeAccountLimitsResponse>">>,
+
+            [[{describe_account_limits_result,[[{
+                    account_limits, [[{member, [[
+                                    {name, "Name"},
+                                    {value, "Value"}
+                                ]]}]]
+                }]]},
+            {response_meta, [[{request_id, "Request ID"}]]}]]
+        }),
+
+    output_test(?_f(erlcloud_cloudformation:describe_account_limits_all(
+                Config = #aws_config{}
+            )), Test).


### PR DESCRIPTION
### Problem
* Would like to be able to call get/list/describe functions for aws cloudformation

### Solution
* New Cloudformation module with all non PUT/DELETE API functions