### PR TITLE
Change cloudwatch service name for monitoring

### DIFF
--- a/src/erlcloud_mon.erl
+++ b/src/erlcloud_mon.erl
@@ -260,7 +260,7 @@ mon_query(Config, Action, Params, ApiVersion) ->
                                  Config#aws_config.mon_port,
                                  "/",
                                  QParams,
-                                 "cloudwatch",
+                                 "monitoring",
                                  Config)
     of
         {ok, Body} ->


### PR DESCRIPTION
Hello,

I tried to push some metrics to AWS Cloudwatch and I got this error:

```
"<ErrorResponse xmlns="http://monitoring.amazonaws.com/doc/2010-08-01"><Error>    <Type>Sender</Type> 
<Code>SignatureDoesNotMatch</Code>
<Message>Credential should be scoped to correct service: 'monitoring'. </Message>
```

I think that the name of the Service should be `monitoring` instead of `cloudwatch`. Changing it fixed the problem for me.