### PR TITLE
[DynamoDB] Add write_all, put_all and delete_all

### DIFF
--- a/src/erlcloud_ddb2.erl
+++ b/src/erlcloud_ddb2.erl
@@ -68,7 +68,7 @@
 %% to handle conditional check failures, match `{error,
 %% {<<"ConditionalCheckFailedException">>, _}}'.
 %%
-%% `erlcloud_ddb_impl' provides a higher level API that implements common
+%% `erlcloud_ddb_util' provides a higher level API that implements common
 %% operations that may require multiple DynamoDB API calls.
 %%
 %% See the unit tests for additional usage examples beyond what are

--- a/test/erlcloud_ddb_util_tests.erl
+++ b/test/erlcloud_ddb_util_tests.erl
@@ -26,8 +26,10 @@ operation_test_() ->
     {foreach,
      fun start/0,
      fun stop/1,
-     [fun delete_hash_key_tests/1,
+     [fun delete_all_tests/1,
+      fun delete_hash_key_tests/1,
       fun get_all_tests/1,
+      fun put_all_tests/1,
       fun q_all_tests/1,
       fun scan_all_tests/1,
       fun write_all_tests/1
@@ -92,6 +94,33 @@ multi_call_tests(Tests) ->
 %%%===================================================================
 %%% Actual test specifiers
 %%%===================================================================
+
+delete_all_tests(_) ->
+    Tests =
+        [?_ddb_test(
+            {"delete_all delete one item",
+             ?_f(erlcloud_ddb_util:delete_all(<<"tn">>, [{<<"hkn">>,<<"hkv">>}])),
+             [{"
+{
+    \"RequestItems\": {
+        \"tn\": [{
+            \"DeleteRequest\": {
+                \"Key\": {
+                    \"hkn\":{\"S\":\"hkv\"}
+                }
+            }
+        }]
+    }
+}"
+               , "
+{
+    \"UnprocessedItems\": {
+    }
+}"
+               }],
+             ok})
+         ],
+    multi_call_tests(Tests).
 
 delete_hash_key_tests(_) ->
     Tests =
@@ -374,6 +403,34 @@ get_all_tests(_) ->
              {ok, [[{<<"hkn">>, <<"hk2">>}],
                    [{<<"hkn">>, <<"hk1">>}]
                   ]}})
+         ],
+    multi_call_tests(Tests).
+
+put_all_tests(_) ->
+    Tests =
+        [?_ddb_test(
+            {"put_all put one item",
+             ?_f(erlcloud_ddb_util:put_all(<<"tn">>, [[{<<"hkn">>,<<"hkv">>}, {<<"atn">>,<<"atv">>}]])),
+             [{"
+{
+    \"RequestItems\": {
+        \"tn\": [{
+            \"PutRequest\": {
+                \"Item\": {
+                    \"hkn\":{\"S\":\"hkv\"},
+                    \"atn\":{\"S\":\"atv\"}
+                }
+            }
+        }]
+    }
+}"
+               , "
+{
+    \"UnprocessedItems\": {
+    }
+}"
+               }],
+             ok})
          ],
     multi_call_tests(Tests).
 


### PR DESCRIPTION
* Add `write_all` to `erlcloud_ddb_util.erl`, using parallel `batch_write_item` calls;
* Add two convenient functions sets: `put_all` and `delete_all`, use `write_all` as backend;
* Update some **unexported** type specs in `erlcloud_ddb_util.erl` for clarity.